### PR TITLE
refactor(instructions): translate all instruction files to English

### DIFF
--- a/instructions/al-agent-toolkit.instructions.md
+++ b/instructions/al-agent-toolkit.instructions.md
@@ -5,39 +5,39 @@ description: "AL Agent Toolkit / BC Agents Pack — non-negotiable rules for cod
 
 # AL Agent Toolkit — Always-On Rules
 
-Reglas que se aplican siempre que se edite código AL relacionado con el AI Development Toolkit o Agent SDK. Solo reglas. El conocimiento detallado (arquitectura, firmas de interfaces, patterns) vive en skills.
+Rules that apply whenever AL code related to the AI Development Toolkit or Agent SDK is edited. Rules only. Detailed knowledge (architecture, interface signatures, patterns) lives in skills.
 
 ## Knowledge sources
 
-Para contenido detallado, carga el skill correspondiente:
+For detailed content, load the corresponding skill:
 
-| Skill                          | Cuándo                                                                   |
+| Skill                          | When                                                                     |
 | ------------------------------ | ------------------------------------------------------------------------ |
-| `skill-agent-toolkit`          | Arquitectura SDK, 3 interfaces, Setup Codeunit, ConfigurationDialog, Install/Upgrade, project structure |
-| `skill-agent-task-patterns`    | Public API, Agent Task Builder, attachments, multi-turn, session detection, API availability por runtime |
-| `skill-agent-instructions`     | Redactar `InstructionsV1.txt` (framework RGI + keywords)                 |
+| `skill-agent-toolkit`          | SDK architecture, 3 interfaces, Setup Codeunit, ConfigurationDialog, Install/Upgrade, project structure |
+| `skill-agent-task-patterns`    | Public API, Agent Task Builder, attachments, multi-turn, session detection, API availability per runtime |
+| `skill-agent-instructions`     | Authoring `InstructionsV1.txt` (RGI framework + keywords)                |
 
 ## Non-negotiable rules
 
-1. **Public API es el entry point estándar** — toda creación de tasks pasa por un codeunit `Access = Public`; el resto de patterns (page action, event subscriber, multi-turn) llama por aquí.
-2. **TryFunction obligatorio en event-driven task creation** — nunca se bloquea un posting/release/approval por un fallo del agente.
-3. **Filtrar antes de crear** — la condición de negocio se evalúa ANTES del `Create()` del task builder, nunca dentro.
-4. **Telemetría en cada fallo** — `Session.LogMessage` con categoría y `GetLastErrorText()`. Sin excepción.
-5. **ExternalId con convención `{PREFIX}-{No.}`** — `SO-1001`, `LEAD-001`, `INV-103456`, `EMAIL-{threadId}`. Nunca GUID, nunca número correlativo.
-6. **Mensaje del task contiene TODO el contexto** — el agente solo sabe lo que se le pasa por el mensaje + adjuntos.
-7. **Agent Task Message Builder** se usa para attachments y para controlar sanitización; nunca se manipulan campos del builder por reflexión.
-8. **Instrucciones en inglés** — los safeguards del runtime están optimizados para inglés.
+1. **Public API is the standard entry point** — all task creation goes through a codeunit with `Access = Public`; all other patterns (page action, event subscriber, multi-turn) call through here.
+2. **TryFunction mandatory for event-driven task creation** — a posting/release/approval must never be blocked by an agent failure.
+3. **Filter before creating** — the business condition is evaluated BEFORE the task builder's `Create()`, never inside it.
+4. **Telemetry on every failure** — `Session.LogMessage` with category and `GetLastErrorText()`. No exceptions.
+5. **ExternalId with convention `{PREFIX}-{No.}`** — `SO-1001`, `LEAD-001`, `INV-103456`, `EMAIL-{threadId}`. Never a GUID, never a sequential number.
+6. **Task message contains ALL the context** — the agent only knows what is passed via the message + attachments.
+7. **Agent Task Message Builder** is used for attachments and sanitization control; builder fields are never manipulated via reflection.
+8. **Instructions in English** — the runtime safeguards are optimized for English.
 
 ## Naming conventions
 
-| Objeto                       | Patrón                                                      |
+| Object                       | Pattern                                                     |
 | ---------------------------- | ----------------------------------------------------------- |
 | Copilot Capability EnumExt   | `"{Agent} Copilot Capability"` extends `"Copilot Capability"` |
 | Metadata Provider EnumExt    | `"{Agent} Metadata Provider"` extends `"Agent Metadata Provider"` |
 | Factory codeunit             | `{Agent}Factory` implements `IAgentFactory`                 |
 | Metadata codeunit            | `{Agent}Metadata` implements `IAgentMetadata`               |
 | Task Execution codeunit      | `{Agent}TaskExecution` implements `IAgentTaskExecution`     |
-| Setup codeunit               | `"{Agent} Setup"` — lógica centralizada                     |
+| Setup codeunit               | `"{Agent} Setup"` — centralized logic                       |
 | Install codeunit             | `"{Agent} Install"` (Subtype = Install)                     |
 | Upgrade codeunit             | `"{Agent} Upgrade"` (Subtype = Upgrade)                     |
 | Public API codeunit          | `"{Agent} Public API"` (Access = Public) + Impl internal    |
@@ -45,21 +45,21 @@ Para contenido detallado, carga el skill correspondiente:
 | KPI table / page             | `"{Agent} KPI"` / CardPart                                  |
 | Setup page                   | `"{Agent} Setup"` (PageType = ConfigurationDialog)          |
 | Profile / RoleCenter         | `"{Agent} Profile"` / `"{Agent} Role Center"`               |
-| PermissionSet                | `"{Agent}"` (Assignable, incluye D365 BASIC)                |
+| PermissionSet                | `"{Agent}"` (Assignable, includes D365 BASIC)               |
 
-## ConfigurationDialog page — invariantes
+## ConfigurationDialog page — invariants
 
-`PageType = ConfigurationDialog` exige:
+`PageType = ConfigurationDialog` requires:
 
 - `SourceTableTemporary = true`
 - `Extensible = false`
 - `InherentEntitlements = X` + `InherentPermissions = X`
-- Primer elemento del layout: `part(AgentSetupPart; "Agent Setup Part")`
-- `OnOpenPage` comprueba `AzureOpenAI.IsEnabled(<capability>)`
-- `OnQueryClosePage` delega en el Setup Codeunit
-- System actions: `OK` (gated por `IsUpdated`) + `Cancel`, sin custom triggers
+- First layout element: `part(AgentSetupPart; "Agent Setup Part")`
+- `OnOpenPage` checks `AzureOpenAI.IsEnabled(<capability>)`
+- `OnQueryClosePage` delegates to the Setup Codeunit
+- System actions: `OK` (gated by `IsUpdated`) + `Cancel`, no custom triggers
 
-## Project structure (referencia)
+## Project structure (reference)
 
 ```
 app/
@@ -75,4 +75,4 @@ app/
     └── TaskExecution/
 ```
 
-Detalle de cada carpeta y ejemplos completos en `skill-agent-toolkit`.
+Details on each folder and complete examples in `skill-agent-toolkit`.

--- a/instructions/al-code-style.instructions.md
+++ b/instructions/al-code-style.instructions.md
@@ -5,10 +5,10 @@ description: "AL Code structure, formatting, and folder organization guidelines 
 
 # AL Code Style — Micro Rules
 
-Reglas duras de estilo. Profundidad y ejemplos en `skill-pages` y demás skills de dominio.
+Hard style rules. Depth and examples in `skill-pages` and other domain skills.
 
-1. **Indentación**: 2 espacios. Sin tabuladores. Sin mezcla.
-2. **PascalCase** para variables, procedures y nombres de objeto AL.
-3. **Organización por feature**, no por tipo de objeto: `src/<Feature>/<SubFeature>/...`. Compartido en `Common/` o `Shared/`. Nunca carpetas `Tables/`, `Pages/`, `Codeunits/`.
-4. **Procedures focalizadas**: una procedure hace una cosa. Si supera ~40 líneas o mezcla validación + cálculo + persistencia, divídela.
-5. **Comentarios solo cuando el porqué no es obvio**. XML doc (`/// <summary>`) es obligatoria solo en procedures `public` de codeunits expuestos como API.
+1. **Indentation**: 2 spaces. No tabs. No mixing.
+2. **PascalCase** for variables, procedures and AL object names.
+3. **Feature-based organization**, not by object type: `src/<Feature>/<SubFeature>/...`. Shared code in `Common/` or `Shared/`. Never `Tables/`, `Pages/`, `Codeunits/` folders.
+4. **Focused procedures**: one procedure does one thing. If it exceeds ~40 lines or mixes validation + calculation + persistence, split it.
+5. **Comments only when the why is not obvious**. XML doc (`/// <summary>`) is mandatory only on `public` procedures of codeunits exposed as APIs.

--- a/instructions/al-error-handling.instructions.md
+++ b/instructions/al-error-handling.instructions.md
@@ -5,10 +5,10 @@ description: "AL Error handling patterns, debugging techniques, and troubleshoot
 
 # AL Error Handling — Micro Rules
 
-Reglas duras de gestión de errores en codeunits. Profundidad, patrones y ejemplos en `skill-debug` y skills relacionadas.
+Hard error handling rules for codeunits. Depth, patterns and examples in `skill-debug` and related skills.
 
-1. **TryFunction obligatoria** cuando la operación puede fallar por causa externa (servicios HTTP, parsing, llamadas a otra app) o necesita rollback. Recupera el texto con `GetLastErrorText()`.
-2. **Toda cadena de error/warning/mensaje al usuario va en un `Label`** con `Comment` para traductores. Nada de literales `Error('...')` o `Message('...')` en línea.
-3. **Labels técnicos** (telemetría, claves, identificadores no traducibles): `Locked = true`.
-4. **Telemetría custom** (`Session.LogMessage`) **solo si el usuario la pide explícitamente**. No la añadas por iniciativa propia.
-5. **Nunca silencies un error**. Un `if not TryX() then exit;` sin loggear ni propagar es bug.
+1. **TryFunction mandatory** when the operation can fail due to external causes (HTTP services, parsing, calls to another app) or needs rollback. Retrieve the text with `GetLastErrorText()`.
+2. **Every error/warning/user message string goes in a `Label`** with `Comment` for translators. No inline `Error('...')` or `Message('...')` literals.
+3. **Technical labels** (telemetry, keys, non-translatable identifiers): `Locked = true`.
+4. **Custom telemetry** (`Session.LogMessage`) **only if the user explicitly requests it**. Do not add it on your own initiative.
+5. **Never silence an error**. An `if not TryX() then exit;` without logging or propagating is a bug.

--- a/instructions/al-events.instructions.md
+++ b/instructions/al-events.instructions.md
@@ -5,10 +5,10 @@ description: "Guidelines for implementing event-driven patterns and extensibilit
 
 # AL Events — Micro Rules
 
-Reglas duras de eventos en codeunits. Patrones (integration events, handled, OnBefore/OnAfter) y ejemplos viven en `skill-events`.
+Hard event rules for codeunits. Patterns (integration events, handled, OnBefore/OnAfter) and examples live in `skill-events`.
 
-1. **Nunca modificar objetos base de Business Central**. Toda extensión va por event subscriber o table/page extension.
-2. **Event subscribers `local`**, con la **firma exacta** del evento publicado (tipos, `var`, orden). Una firma desalineada compila pero no engancha.
-3. **Par OnBefore/OnAfter** alrededor de operaciones extensibles (`OnBeforeCreateX`/`OnAfterCreateX`), con `IsHandled` cuando el subscriber debe poder cortar el flujo por defecto.
-4. **Prohibido `Commit` dentro de un event subscriber**. Rompe la transacción del publicador y deja datos inconsistentes.
-5. **Codeunits que solo subscriben terminan en `Handler`** (`SalesPostingHandler`) y solo contienen subscribers — sin lógica de negocio propia.
+1. **Never modify Business Central base objects**. All extensions go through event subscribers or table/page extensions.
+2. **Event subscribers `local`**, with the **exact signature** of the published event (types, `var`, order). A misaligned signature compiles but does not hook.
+3. **OnBefore/OnAfter pair** around extensible operations (`OnBeforeCreateX`/`OnAfterCreateX`), with `IsHandled` when the subscriber must be able to abort the default flow.
+4. **`Commit` is forbidden inside an event subscriber**. It breaks the publisher's transaction and leaves inconsistent data.
+5. **Codeunits that only subscribe end in `Handler`** (`SalesPostingHandler`) and contain only subscribers — no own business logic.

--- a/instructions/al-guidelines.instructions.md
+++ b/instructions/al-guidelines.instructions.md
@@ -5,9 +5,9 @@ description: "AL Core principles — transversal rules for Microsoft Dynamics 36
 
 # AL Core Principles
 
-Principios transversales del framework. Las reglas concretas de estilo, naming, performance, errores, eventos y testing viven en sus propias micro-instructions.
+Transversal framework principles. Concrete rules for style, naming, performance, errors, events and testing live in their own micro-instructions.
 
-1. **Modelo event-driven**. Nunca modificar objetos base de Business Central; extender vía event subscribers o table/page extensions.
-2. **Foco en la App por defecto**. Implementación principal en `App/`; los tests **solo se generan si el usuario los pide explícitamente**.
-3. **Separación AL-Go App/Test**. El proyecto `Test/` depende de `App/`; nunca al revés. No mezclar lógica de aplicación con tests.
-4. **Naming es infraestructura**. El patrón `<ObjectName>.<ObjectType>.al` no es estético: los globs estrechos de otras instructions dependen de él. Un fichero mal nombrado queda sin sus reglas.
+1. **Event-driven model**. Never modify Business Central base objects; extend via event subscribers or table/page extensions.
+2. **App focus by default**. Main implementation in `App/`; tests **are only generated if the user explicitly requests them**.
+3. **AL-Go App/Test separation**. The `Test/` project depends on `App/`; never the other way around. Do not mix application logic with tests.
+4. **Naming is infrastructure**. The pattern `<ObjectName>.<ObjectType>.al` is not aesthetic: the narrow globs in other instructions depend on it. A misnamed file silently misses its rules.

--- a/instructions/al-naming-conventions.instructions.md
+++ b/instructions/al-naming-conventions.instructions.md
@@ -5,10 +5,10 @@ description: "Comprehensive naming conventions for AL files, objects, variables,
 
 # AL Naming Conventions — Micro Rules
 
-Reglas duras de naming. La nomenclatura de ficheros es **infraestructura del framework**: los globs estrechos de otras instructions dependen de ella.
+Hard naming rules. File naming is **framework infrastructure**: the narrow globs in other instructions depend on it.
 
-1. **PascalCase** en todo: nombres de objeto (table, page, codeunit, report…), variables, parámetros y procedures.
-2. **Límite 30 caracteres** en el nombre del objeto; reservar 4 para prefijo/sufijo → **el nombre propio no excede 26 caracteres**. Nada de abreviaturas crípticas (`CustLE`, `SIPoster`).
-3. **Nombre de fichero**: `<ObjectName>.<ObjectType>.al` (p.ej. `NoSeries.Table.al`, `SalesPosting.Codeunit.al`, `Customer.PageExt.al`). **Requisito**, no estilo: si el fichero no sigue el patrón, no carga sus instructions específicas de tipo.
-4. **Interfaces** con prefijo `I` (`INoSeries`). **Implementaciones** con sufijo `Impl` (`NoSeriesImpl`). Mismo nombre raíz que la interfaz.
-5. **Parámetros de event subscribers** descriptivos (`SalesHeader`, `Customer`), nunca genéricos (`Rec`, `xRec` salvo cuando la firma del evento lo exija).
+1. **PascalCase** everywhere: object names (table, page, codeunit, report…), variables, parameters and procedures.
+2. **30-character limit** on object names; reserve 4 for prefix/suffix → **the own name must not exceed 26 characters**. No cryptic abbreviations (`CustLE`, `SIPoster`).
+3. **File name**: `<ObjectName>.<ObjectType>.al` (e.g. `NoSeries.Table.al`, `SalesPosting.Codeunit.al`, `Customer.PageExt.al`). **Requirement**, not style: if the file does not follow the pattern, its type-specific instructions will not load.
+4. **Interfaces** with prefix `I` (`INoSeries`). **Implementations** with suffix `Impl` (`NoSeriesImpl`). Same root name as the interface.
+5. **Event subscriber parameters** should be descriptive (`SalesHeader`, `Customer`), never generic (`Rec`, `xRec` unless the event signature requires it).

--- a/instructions/al-performance.instructions.md
+++ b/instructions/al-performance.instructions.md
@@ -5,10 +5,10 @@ description: "Performance optimization guidelines and best practices for AL deve
 
 # AL Performance — Micro Rules
 
-Reglas duras red-de-seguridad. Patrones, triage de AL0896 y ejemplos viven en `skill-performance`.
+Hard safety-net rules. Patterns, AL0896 triage and examples live in `skill-performance`.
 
-1. **`SetRange`/`SetFilter` antes de `Find`/`FindSet`/`FindFirst`**. Filtrar pronto, no procesar y filtrar después.
-2. **`SetLoadFields` antes de `Get`/`Find`** cuando solo se usan algunas columnas. El orden importa: `SetLoadFields` → `SetRange` → `Find`.
-3. **`CalcSums` en lugar de bucles de acumulación**. Si necesitas un total, no itera y suma — usa la agregación de la plataforma.
-4. **Nada de llamadas a base de datos dentro de bucles** (`Get`, `FindFirst`, `CalcFields` por registro). Precarga en `Dictionary`/`temporary` o usa `SetAutoCalcFields` antes del bucle.
-5. **Una sola escritura por registro modificado**: calcula todos los cambios en memoria y emite un único `Modify(true)`.
+1. **`SetRange`/`SetFilter` before `Find`/`FindSet`/`FindFirst`**. Filter early, do not process then filter.
+2. **`SetLoadFields` before `Get`/`Find`** when only some columns are used. Order matters: `SetLoadFields` → `SetRange` → `Find`.
+3. **`CalcSums` instead of accumulation loops**. If you need a total, do not iterate and sum — use the platform aggregation.
+4. **No database calls inside loops** (`Get`, `FindFirst`, `CalcFields` per record). Preload into `Dictionary`/`temporary` or use `SetAutoCalcFields` before the loop.
+5. **One write per modified record**: compute all changes in memory and issue a single `Modify(true)`.

--- a/instructions/al-testing.instructions.md
+++ b/instructions/al-testing.instructions.md
@@ -5,10 +5,10 @@ description: "AL Testing & Project Structure Rules - Ensure proper project organ
 
 # AL Testing — Micro Rules
 
-Reglas duras para ficheros de test. Patrones de test (given/when/then, libraries, asserts) y ejemplos en `skill-testing`.
+Hard rules for test files. Test patterns (given/when/then, libraries, asserts) and examples in `skill-testing`.
 
-1. **No generes tests salvo que se pidan explícitamente** ("create tests for…", "add test coverage", "write unit tests…"). Por defecto, foco en la App.
-2. **Separación AL-Go estricta**: tests solo en el proyecto `Test/`, nunca en `App/`. El `app.json` de Test depende del de App; el de App **no** depende de Test.
-3. **Estructura de Test/ refleja la de App/**: si `App/src/Sales/Invoice/...` existe, los tests viven en `Test/src/Sales/Invoice/...`. Helpers compartidos en `Test/src/Common/`.
-4. **Codeunit con `Subtype = Test`** y dependencias estándar: `Codeunit Assert`, `Library - <Module>` (Sales, Inventory, ERM, Random). Usa esas libraries para crear datos y postear documentos — no construyas registros a mano.
-5. **Nombres de test method en patrón Given/When/Then**: `GivenX_WhenY_ThenZ`. Cada test cierra con uno o más `Assert.*` explícitos.
+1. **Do not generate tests unless explicitly requested** ("create tests for…", "add test coverage", "write unit tests…"). Default focus is on the App.
+2. **Strict AL-Go separation**: tests only in the `Test/` project, never in `App/`. The `app.json` of Test depends on App's; App's does **not** depend on Test.
+3. **Test/ structure mirrors App/**: if `App/src/Sales/Invoice/...` exists, tests live in `Test/src/Sales/Invoice/...`. Shared helpers in `Test/src/Common/`.
+4. **Codeunit with `Subtype = Test`** and standard dependencies: `Codeunit Assert`, `Library - <Module>` (Sales, Inventory, ERM, Random). Use those libraries to create data and post documents — do not build records by hand.
+5. **Test method names in Given/When/Then pattern**: `GivenX_WhenY_ThenZ`. Each test ends with one or more explicit `Assert.*` calls.


### PR DESCRIPTION
## Summary

Translates all Spanish content to English across the instruction files and documentation templates.

### Files changed

**Instructions** (`instructions/`):
- `al-guidelines.instructions.md` — intro + all 4 core principles
- `al-code-style.instructions.md` — intro + all 5 style rules
- `al-naming-conventions.instructions.md` — intro + all 5 naming rules
- `al-performance.instructions.md` — intro + all 5 performance rules
- `al-error-handling.instructions.md` — intro + all 5 error handling rules
- `al-events.instructions.md` — intro + all 5 event rules
- `al-testing.instructions.md` — intro + all 5 testing rules
- `al-agent-toolkit.instructions.md` — intro, knowledge sources table, all 8 non-negotiable rules, naming table, ConfigurationDialog section, project structure

**Templates** (`docs/templates/`):
- `architecture-template.md` — all section headings and field labels
- `delivery-template.md` — all section headings and field labels
- `spec-template.md` — all section headings, table headers and field labels
- `technical-spec-template.md` — title, phase plan, Definition of Done
- `test-plan-template.md` — all section headings and table headers