### PR TITLE
chore: bump package.json to 4.0.0 for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "al-development-collection",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "AI Native AL Development toolkit for Microsoft Dynamics 365 Business Central with GitHub Copilot integration",
   "main": "scripts/install.js",
   "bin": {


### PR DESCRIPTION
## Summary

Bumps the repository `package.json` version from `3.2.0` to `4.0.0` ahead of the v4.0.0 release.

This keeps the artifact attached by the release workflow (`package.json`) consistent with the `v4.0.0` tag and the `[4.0.0]` CHANGELOG entry.

## Notes

- One-line change. No functional impact.
- Prerequisite for creating the `v4.0.0` tag / GitHub Release.

> Draft — merge before tagging v4.0.0.

https://claude.ai/code/session_01Wywa2Sc5t1qKUy74BNyeTg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wywa2Sc5t1qKUy74BNyeTg)_