### PR TITLE
feat(bcquality): configurable knowledge source, default upstream microsoft/BCQuality

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -81,7 +81,7 @@ Project estimation?        → @AL Pre-Sales & Project Estimation Specialist
 
 ## External Knowledge: BCQuality
 
-[BCQuality](https://github.com/javiarmesto/bcquality) — a curated, citable knowledge base of Business Central guidance (atomic knowledge files + review skills), pinned as a fork — is consumed from **outside the AL project**: a pinned clone added as a second VS Code workspace root (multi-root via `aldc.code-workspace`), so its example `.al` files never enter your extension's compilation. See [`docs/bcquality.md`](../docs/bcquality.md) for install + usage.
+[BCQuality](https://github.com/microsoft/BCQuality) — a curated, citable knowledge base of Business Central guidance (atomic knowledge files + review skills) — is consumed from **outside the AL project**: a clone added as a second VS Code workspace root (multi-root via `aldc.code-workspace`), so its example `.al` files never enter your extension's compilation. Source/version is configurable in `aldc.yaml → external.bcquality` (defaults to upstream; point it at your own fork). See [`docs/bcquality.md`](../docs/bcquality.md) for install + usage.
 
 BCQuality is a **citation/audit layer, not a replacement** for the 7 auto-applied instructions or the 11 skills. The **AL Code Review Subagent** consults it (its "Step 0") before the A-G checklist: it routes via the BCQuality entry point (`<home>/skills/entry.md`, per `aldc.yaml`), runs the dispatched review skills, and folds the resulting findings — each backed by a knowledge-file citation — into the review report. A BCQuality `blocker`/`major` raises the review verdict like a native CRITICAL/MAJOR.
 

--- a/.github/workflows/bcquality-evidence.yaml
+++ b/.github/workflows/bcquality-evidence.yaml
@@ -28,14 +28,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Clone BCQuality at the pinned SHA
+      - name: Clone BCQuality (url/ref/pin from aldc.yaml)
         run: |
           set -euo pipefail
-          PIN=$(grep -oE 'pinnedCommit:[[:space:]]*"?[0-9a-f]{40}"?' aldc.yaml | grep -oE '[0-9a-f]{40}')
-          URL=$(grep -E '^\s*url:' aldc.yaml | grep bcquality | head -1 | sed -E 's/.*"(.*)".*/\1/')
-          echo "Cloning $URL @ $PIN"
+          URL=$(grep -E '^\s*url:'  aldc.yaml | head -1 | sed -E 's/.*url:[[:space:]]*"?([^"#]+)"?.*/\1/'  | tr -d '[:space:]')
+          REF=$(grep -E '^\s*ref:'  aldc.yaml | head -1 | sed -E 's/.*ref:[[:space:]]*"?([^"#]+)"?.*/\1/'  | tr -d '[:space:]')
+          PIN=$(grep -oE 'pinnedCommit:[[:space:]]*"?[0-9a-f]{40}"?' aldc.yaml | grep -oE '[0-9a-f]{40}' || true)
+          TARGET="${PIN:-${REF:-main}}"
+          echo "Cloning $URL @ $TARGET"
           git clone --filter=blob:none "$URL" "$RUNNER_TEMP/bcquality"
-          git -C "$RUNNER_TEMP/bcquality" checkout --quiet "$PIN"
+          git -C "$RUNNER_TEMP/bcquality" checkout --quiet "$TARGET"
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ ALDC (AL Development Collection) transforms how you develop Business Central ext
 
 **BCQuality (optional)** — External, citable BC knowledge layer for reviews & audits
 
-- A pinned fork consumed externally (multi-root); agents cite findings to real knowledge files, with a graceful native fallback when it is absent. See [`docs/bcquality.md`](docs/bcquality.md).
+- An externally-consumed BC knowledge base (multi-root) — defaults to the canonical upstream [`microsoft/BCQuality`](https://github.com/microsoft/BCQuality), configurable to your own fork. Agents cite findings to real knowledge files, with a graceful native fallback when it is absent. See [`docs/bcquality.md`](docs/bcquality.md).
 
 **11 Composable Skills** — Domain knowledge loaded on demand
 
@@ -364,7 +364,7 @@ AL-Development-Collection-for-GitHub-Copilot/
 
 ## Using BCQuality (optional)
 
-BCQuality is an optional, externally-consumed BC knowledge layer for cited reviews and audits. It is a pinned fork ([github.com/javiarmesto/bcquality](https://github.com/javiarmesto/bcquality)) consumed via multi-root workspace — **not a submodule, never compiled**. When absent, agents fall back gracefully to the native A–G checklist and are never blocked.
+BCQuality is an optional, externally-consumed BC knowledge layer for cited reviews and audits. The source is configurable in `aldc.yaml` and defaults to the canonical upstream [microsoft/BCQuality](https://github.com/microsoft/BCQuality) (point it at your own fork if you keep one); it is consumed via a multi-root workspace — **not a submodule, never compiled**. When absent, agents fall back gracefully to the native A–G checklist and are never blocked.
 
 **Quick start (3 steps):**
 

--- a/aldc.yaml
+++ b/aldc.yaml
@@ -12,8 +12,13 @@ toolkitRoot: "."
 external:
   bcquality:
     mode: "external-multiroot"            # consumed from OUTSIDE the AL project (see aldc.code-workspace)
-    url: "https://github.com/javiarmesto/bcquality.git"
-    pinnedCommit: "07efef6bc719f32c7dded1b2e00d1d12080a2830"
+    # Source of the knowledge base. Configurable: defaults to the canonical upstream
+    # (microsoft/BCQuality). Override `url` to point at your own fork. The install
+    # scripts read `url` / `ref` / `pinnedCommit` from here — this file is the single
+    # source of truth.
+    url: "https://github.com/microsoft/BCQuality.git"
+    ref: "main"                           # branch/tag to track when pinnedCommit is empty
+    pinnedCommit: ""                       # optional: set a 40-hex SHA for reproducible, pinned evidence
     home: "../bcquality"                  # external clone location (override: $BCQUALITY_HOME); 2nd workspace root
     entryPoint: "skills/entry.md"         # relative to `home`
     workspace: "aldc.code-workspace"      # multi-root workspace (this repo root + ../bcquality); see docs/bcquality.md

--- a/docs/bcquality.md
+++ b/docs/bcquality.md
@@ -9,31 +9,38 @@ reviews.
 
 ## How the integration works
 
-- **It is a fork, consumed externally — not a submodule.** ALDC pins a fork of
-  BCQuality (`https://github.com/javiarmesto/bcquality.git`) at a known commit and
-  clones it **outside** your AL project (a sibling folder, default `../bcquality`).
-  Because that clone has no `app.json`, the AL compiler never builds it, so its
-  example `.al` files can't pollute your extension's error list.
+- **Consumed externally — not a submodule.** ALDC clones BCQuality **outside** your
+  AL project (a sibling folder, default `../bcquality`). Because that clone has no
+  `app.json`, the AL compiler never builds it, so its example `.al` files can't
+  pollute your extension's error list.
+- **The source is configurable; the default is the canonical upstream.** Out of the
+  box `aldc.yaml → external.bcquality.url` points at **[`microsoft/BCQuality`](https://github.com/microsoft/BCQuality)**
+  (the source of truth). Point `url` at **your own fork** if you maintain one. By
+  default it tracks the `ref` branch (`main`); set `pinnedCommit` to a 40-hex SHA for
+  reproducible, evidence-validated runs.
 - **ALDC "hooks in" by calling the meta-skill `entry.md`.** The agents do **not**
   hardcode which BCQuality skills to run. They read the entry point
   (`<home>/skills/entry.md`, per `aldc.yaml`) and **execute whatever its `dispatch[]`
-  returns** — Entry owns the routing. As the fork's coverage grows, ALDC picks it up
+  returns** — Entry owns the routing. As BCQuality's coverage grows, ALDC picks it up
   with no change on this side.
-- **Configuration lives in `aldc.yaml → external.bcquality`**: the fork `url`, the
-  `pinnedCommit`, the `home` (clone location), the `entryPoint` (`skills/entry.md`),
-  the multi-root `workspace`, and the absent-path `fallback` policy.
+- **Configuration lives in `aldc.yaml → external.bcquality`**: `url`, `ref`,
+  optional `pinnedCommit`, `home` (clone location), `entryPoint` (`skills/entry.md`),
+  the multi-root `workspace`, and the absent-path `fallback` policy. The install
+  scripts read `url`/`ref`/`pinnedCommit` from here — it is the single source of truth.
 
 ## Install (only if you want BCQuality-backed reviews)
 
 From your **AL project root**:
 
-1. **Clone the pinned fork.**
+1. **Clone the knowledge base.**
    - macOS / Linux / Git Bash / WSL: `bash tools/bcquality/install.sh`
    - Windows (PowerShell): `pwsh -File tools/bcquality/install.ps1`
 
-   This clones `javiarmesto/bcquality` to `../bcquality` at the pinned commit
-   (override the location with `$BCQUALITY_HOME`). The scripts are idempotent and
-   verify `skills/entry.md` exists.
+   This reads `url` / `ref` / `pinnedCommit` from `aldc.yaml` and clones BCQuality to
+   `../bcquality` (default upstream `microsoft/BCQuality`; override the location with
+   `$BCQUALITY_HOME`). The scripts are idempotent and verify `skills/entry.md` exists.
+   To use your own fork or a fixed version, edit `external.bcquality` in `aldc.yaml`
+   before running.
 
 2. **Open the multi-root workspace.** Open `aldc.code-workspace` in VS Code. It adds
    two roots — your extension (compiled) and `../bcquality` (knowledge, *not*
@@ -49,14 +56,15 @@ From your **AL project root**:
 
 ## Pin & evidence
 
-The fork is **pinned** to one commit, asserted in three places that must agree:
-`external.bcquality.pinnedCommit` in `aldc.yaml` and the hardcoded pin in both
-install scripts. `tools/bcquality/validate_evidence.py` (run by the
-`bcquality-evidence` CI workflow) checks that coherence **and** that every citation
-in a persisted review/audit report resolves to a real file **inside** the pinned
-clone — a drifted pin or a hallucinated citation fails the build.
+`aldc.yaml → external.bcquality` is the **single source of truth** for `url`, `ref`
+and the optional `pinnedCommit`; the install scripts and the `bcquality-evidence` CI
+workflow read it from there (nothing is hardcoded). Pinning is **optional**: set
+`pinnedCommit` to a 40-hex SHA for reproducible runs, or leave it empty to track the
+`ref` branch. Either way, `tools/bcquality/validate_evidence.py` checks that every
+citation in a persisted review/audit report resolves to a real file **inside** the
+clone — a hallucinated citation fails the build.
 
-To bump the BCQuality version, update the pin in all three places together.
+To change the source or version, edit `url` / `ref` / `pinnedCommit` in `aldc.yaml`.
 
 ## Notes
 

--- a/tools/bcquality/install.ps1
+++ b/tools/bcquality/install.ps1
@@ -1,14 +1,18 @@
 <#
 .SYNOPSIS
-    Set up the BCQuality knowledge base for an ALDC test repo (Windows/PowerShell).
+    Set up the BCQuality knowledge base for an ALDC workspace (Windows/PowerShell).
 
 .DESCRIPTION
     PowerShell-native equivalent of install.sh. BCQuality is consumed from OUTSIDE
-    the AL project (Option B / multi-root): this clones it to a sibling folder so
-    its example .al files never enter your extension's compilation, then you open
+    the AL project (multi-root): this clones it to a sibling folder so its example
+    .al files never enter your extension's compilation, then you open
     `aldc.code-workspace` to get it as a second workspace root the agents can read.
 
-    Run from the ROOT of the repo/folder you want to run the review/audit test on:
+    The source is CONFIGURABLE via aldc.yaml (external.bcquality): `url`, `ref` and
+    optional `pinnedCommit`. Defaults to the canonical upstream (microsoft/BCQuality);
+    point `url` at your own fork to use it instead.
+
+    Run from the ROOT of the repo/folder you run the review/audit on:
 
         powershell -ExecutionPolicy Bypass -File tools\bcquality\install.ps1
 
@@ -22,9 +26,30 @@ param()
 # $LASTEXITCODE explicitly.
 $ErrorActionPreference = 'Continue'
 
-# --- Pin: keep in sync with aldc.yaml (external.bcquality.pinnedCommit) ---
-$BcqualityUrl = 'https://github.com/javiarmesto/bcquality.git'
-$BcqualityPin = '07efef6bc719f32c7dded1b2e00d1d12080a2830'
+$AldcFile = 'aldc.yaml'
+
+# --- Defaults (used when aldc.yaml is absent or a key is unset) ---
+$BcqualityUrl = 'https://github.com/microsoft/BCQuality.git'
+$BcqualityRef = 'main'
+$BcqualityPin = ''
+
+# Read a scalar key from aldc.yaml (single source of truth). First match wins.
+function Read-Aldc($key) {
+    if (-not (Test-Path $AldcFile)) { return '' }
+    $line = Select-String -Path $AldcFile -Pattern ("^\s*" + $key + ":") | Select-Object -First 1
+    if (-not $line) { return '' }
+    $m = [regex]::Match($line.Line, ($key + ':\s*"?([^"#]*)"?'))
+    if ($m.Success) { return $m.Groups[1].Value.Trim() }
+    return ''
+}
+if (Test-Path $AldcFile) {
+    $u = Read-Aldc 'url';          if ($u) { $BcqualityUrl = $u }
+    $r = Read-Aldc 'ref';          if ($r) { $BcqualityRef = $r }
+    $p = Read-Aldc 'pinnedCommit'; if ($p) { $BcqualityPin = $p }
+}
+
+# What to check out: the pin if set, otherwise the tracking ref (branch/tag).
+$Target = if ($BcqualityPin) { $BcqualityPin } else { $BcqualityRef }
 
 # External knowledge-base location. Default: sibling of this repo, matching the
 # `../bcquality` root in aldc.code-workspace. MUST stay OUTSIDE the AL project.
@@ -38,8 +63,8 @@ if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
     Die 'git is required but was not found on PATH.'
 }
 
-if (-not (Test-Path 'aldc.yaml') -and -not (Test-Path '.github')) {
-    Warn 'No aldc.yaml or .github\ here - make sure you run this from the ROOT of your test repo.'
+if (-not (Test-Path $AldcFile) -and -not (Test-Path '.github')) {
+    Warn 'No aldc.yaml or .github\ here - make sure you run this from the ROOT of your repo.'
 }
 
 # Guard: never let the knowledge base land inside the AL project.
@@ -48,17 +73,17 @@ if (-not ($BcqualityHome -match '^([A-Za-z]:[\\/]|/|\.\.[\\/])')) {
 }
 
 if (Test-Path (Join-Path $BcqualityHome '.git')) {
-    Say "$BcqualityHome exists; fetching and pinning to $BcqualityPin"
-    git -C $BcqualityHome fetch origin
-    git -C $BcqualityHome checkout --quiet $BcqualityPin
-    if ($LASTEXITCODE -ne 0) { Die "Could not checkout $BcqualityPin inside $BcqualityHome." }
+    Say "$BcqualityHome exists; fetching and checking out $Target"
+    git -C $BcqualityHome fetch origin --tags --prune
+    git -C $BcqualityHome checkout --quiet $Target
+    if ($LASTEXITCODE -ne 0) { Die "Could not checkout '$Target' inside $BcqualityHome." }
 }
 else {
-    Say "Cloning BCQuality into $BcqualityHome (outside the AL project)"
+    Say "Cloning BCQuality ($BcqualityUrl) into $BcqualityHome (outside the AL project)"
     git clone $BcqualityUrl $BcqualityHome
     if ($LASTEXITCODE -ne 0) { Die 'git clone failed.' }
-    git -C $BcqualityHome checkout --quiet $BcqualityPin
-    if ($LASTEXITCODE -ne 0) { Die "Could not checkout $BcqualityPin inside $BcqualityHome." }
+    git -C $BcqualityHome checkout --quiet $Target
+    if ($LASTEXITCODE -ne 0) { Die "Could not checkout '$Target' inside $BcqualityHome." }
 }
 
 $entry = Join-Path $BcqualityHome 'skills\entry.md'
@@ -66,15 +91,13 @@ if (-not (Test-Path $entry)) {
     Die "Finished, but $entry is missing - the agents won't find the contract."
 }
 
-$actualPin = (git -C $BcqualityHome rev-parse HEAD).Trim()
-Say "BCQuality ready at $BcqualityHome (HEAD = $actualPin)"
+$actual = (git -C $BcqualityHome rev-parse HEAD).Trim()
+Say "BCQuality ready at $BcqualityHome (HEAD = $actual)"
 
-if (Test-Path 'aldc.yaml') {
-    if (Select-String -Path 'aldc.yaml' -SimpleMatch -Pattern $BcqualityPin -Quiet) {
-        Say 'aldc.yaml pin matches.'
-    } else {
-        Warn "aldc.yaml does not mention $BcqualityPin - align the pin to keep the evidence validator happy."
-    }
+if ($BcqualityPin) {
+    Say "Pinned to $BcqualityPin (aldc.yaml)."
+} else {
+    Warn "No pinnedCommit in aldc.yaml - tracking '$BcqualityRef'. Set external.bcquality.pinnedCommit to a 40-hex SHA for reproducible, evidence-validated runs."
 }
 
 Say "Done. Open 'aldc.code-workspace' in VS Code - BCQuality appears as a second"

--- a/tools/bcquality/install.sh
+++ b/tools/bcquality/install.sh
@@ -1,21 +1,42 @@
 #!/usr/bin/env bash
 #
-# install.sh - set up the BCQuality knowledge base for an ALDC test repo.
+# install.sh - set up the BCQuality knowledge base for an ALDC workspace.
 #
-# BCQuality is consumed from OUTSIDE the AL project (Option B / multi-root): this
-# clones it to a sibling folder so its example .al files never enter your
-# extension's compilation, then you open `aldc.code-workspace` to get it as a
-# second workspace root the agents can read. Run this from the ROOT of the
-# repo/folder you want to run the review/audit test on.
+# BCQuality is consumed from OUTSIDE the AL project (multi-root): this clones it to
+# a sibling folder so its example .al files never enter your extension's compilation,
+# then you open `aldc.code-workspace` to get it as a second workspace root the agents
+# can read. Run this from the ROOT of the repo/folder you run the review/audit on.
+#
+# The source is CONFIGURABLE via aldc.yaml (external.bcquality): `url`, `ref` and
+# optional `pinnedCommit`. Defaults to the canonical upstream (microsoft/BCQuality);
+# point `url` at your own fork to use it instead.
 #
 #   bash install.sh
 #   BCQUALITY_HOME=/some/other/path bash install.sh   # custom location
 #
 set -euo pipefail
 
-# --- Pin: keep in sync with aldc.yaml (external.bcquality.pinnedCommit) ---
-BCQUALITY_URL="https://github.com/javiarmesto/bcquality.git"
-BCQUALITY_PIN="07efef6bc719f32c7dded1b2e00d1d12080a2830"
+ALDC_FILE="aldc.yaml"
+
+# --- Defaults (used when aldc.yaml is absent or a key is unset) ---
+BCQUALITY_URL="https://github.com/microsoft/BCQuality.git"
+BCQUALITY_REF="main"
+BCQUALITY_PIN=""
+
+# Read a scalar key from aldc.yaml (single source of truth). First match wins.
+read_aldc() {
+  [ -f "$ALDC_FILE" ] || return 0
+  grep -E "^[[:space:]]*$1:" "$ALDC_FILE" 2>/dev/null | head -1 \
+    | sed -E "s/.*$1:[[:space:]]*\"?([^\"#]*)\"?.*/\1/" | tr -d '[:space:]'
+}
+if [ -f "$ALDC_FILE" ]; then
+  u="$(read_aldc url)";          [ -n "$u" ] && BCQUALITY_URL="$u"
+  r="$(read_aldc ref)";          [ -n "$r" ] && BCQUALITY_REF="$r"
+  p="$(read_aldc pinnedCommit)"; [ -n "$p" ] && BCQUALITY_PIN="$p"
+fi
+
+# What to check out: the pin if set, otherwise the tracking ref (branch/tag).
+TARGET="${BCQUALITY_PIN:-$BCQUALITY_REF}"
 
 # Where the external knowledge base lives. Default: sibling of this repo, which
 # matches the `../bcquality` root in aldc.code-workspace. MUST stay OUTSIDE the
@@ -29,8 +50,8 @@ die()  { printf '\033[1;31m[x]\033[0m %s\n' "$*" >&2; exit 1; }
 command -v git >/dev/null 2>&1 || die "git is required but was not found on PATH."
 
 # --- Sanity: does this look like the root of an ALDC workspace? ---
-if [ ! -f "aldc.yaml" ] && [ ! -d ".github" ]; then
-  warn "No aldc.yaml or .github/ here - make sure you run this from the ROOT of your test repo."
+if [ ! -f "$ALDC_FILE" ] && [ ! -d ".github" ]; then
+  warn "No aldc.yaml or .github/ here - make sure you run this from the ROOT of your repo."
 fi
 
 # --- Guard: never let the knowledge base land inside the AL project ---
@@ -41,33 +62,30 @@ case "$BCQUALITY_HOME" in
 esac
 
 if [ -d "$BCQUALITY_HOME/.git" ]; then
-  # --- Already cloned -> fetch + pin ---
-  say "$BCQUALITY_HOME exists; fetching and pinning to $BCQUALITY_PIN"
-  git -C "$BCQUALITY_HOME" fetch origin
-  git -C "$BCQUALITY_HOME" checkout --quiet "$BCQUALITY_PIN" \
-    || die "Could not checkout $BCQUALITY_PIN inside $BCQUALITY_HOME."
+  # --- Already cloned -> fetch + check out TARGET ---
+  say "$BCQUALITY_HOME exists; fetching and checking out $TARGET"
+  git -C "$BCQUALITY_HOME" fetch origin --tags --prune
+  git -C "$BCQUALITY_HOME" checkout --quiet "$TARGET" \
+    || die "Could not checkout '$TARGET' inside $BCQUALITY_HOME."
 else
-  # --- Fresh clone + pin (a plain clone, NOT a submodule of this repo) ---
-  say "Cloning BCQuality into $BCQUALITY_HOME (outside the AL project)"
+  # --- Fresh clone + check out TARGET (a plain clone, NOT a submodule of this repo) ---
+  say "Cloning BCQuality ($BCQUALITY_URL) into $BCQUALITY_HOME (outside the AL project)"
   git clone "$BCQUALITY_URL" "$BCQUALITY_HOME" || die "git clone failed."
-  git -C "$BCQUALITY_HOME" checkout --quiet "$BCQUALITY_PIN" \
-    || die "Could not checkout $BCQUALITY_PIN inside $BCQUALITY_HOME."
+  git -C "$BCQUALITY_HOME" checkout --quiet "$TARGET" \
+    || die "Could not checkout '$TARGET' inside $BCQUALITY_HOME."
 fi
 
 # --- Verify the agents will find what they need ---
 [ -f "$BCQUALITY_HOME/skills/entry.md" ] \
   || die "Finished, but $BCQUALITY_HOME/skills/entry.md is missing - the agents won't find the contract."
 
-ACTUAL_PIN="$(git -C "$BCQUALITY_HOME" rev-parse HEAD)"
-say "BCQuality ready at $BCQUALITY_HOME (HEAD = $ACTUAL_PIN)"
+ACTUAL="$(git -C "$BCQUALITY_HOME" rev-parse HEAD)"
+say "BCQuality ready at $BCQUALITY_HOME (HEAD = $ACTUAL)"
 
-# --- Warn if aldc.yaml records a different pin ---
-if [ -f "aldc.yaml" ]; then
-  if grep -q "$BCQUALITY_PIN" aldc.yaml 2>/dev/null; then
-    say "aldc.yaml pin matches."
-  else
-    warn "aldc.yaml does not mention $BCQUALITY_PIN - align the pin to keep the evidence validator happy."
-  fi
+if [ -n "$BCQUALITY_PIN" ]; then
+  say "Pinned to $BCQUALITY_PIN (aldc.yaml)."
+else
+  warn "No pinnedCommit in aldc.yaml - tracking '$BCQUALITY_REF'. Set external.bcquality.pinnedCommit to a 40-hex SHA for reproducible, evidence-validated runs."
 fi
 
 say "Done. Open 'aldc.code-workspace' in VS Code - BCQuality appears as a second"

--- a/tools/bcquality/validate_evidence.py
+++ b/tools/bcquality/validate_evidence.py
@@ -33,16 +33,6 @@ import sys
 
 SHA_RE = re.compile(r'pinnedCommit:\s*"?([0-9a-f]{40})"?')
 
-# Hardcoded pin assignment in the install scripts (bash + PowerShell):
-#   BCQUALITY_PIN="<sha>"   /   $BcqualityPin = '<sha>'
-INSTALL_PIN_RE = re.compile(r'(?:BCQUALITY_PIN|BcqualityPin)\s*=\s*["\']?([0-9a-f]{40})')
-
-# Files that hardcode the pin and must match aldc.yaml's canonical value.
-INSTALL_PIN_FILES = (
-    "tools/bcquality/install.sh",
-    "tools/bcquality/install.ps1",
-)
-
 
 def repo_root() -> str:
     return subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).decode().strip()
@@ -68,16 +58,6 @@ def home_from_aldc(root: str) -> str | None:
         with open(path, encoding="utf-8") as fh:
             m = HOME_RE.search(fh.read())
         return m.group(1).strip() if m else None
-    except OSError:
-        return None
-
-
-def install_pin(root: str, rel_path: str) -> str | None:
-    path = os.path.join(root, rel_path)
-    try:
-        with open(path, encoding="utf-8") as fh:
-            m = INSTALL_PIN_RE.search(fh.read())
-        return m.group(1) if m else None
     except OSError:
         return None
 
@@ -116,20 +96,16 @@ def main() -> int:
     errors: list[str] = []
     notes: list[str] = []
 
-    # --- Check 1: pinned-SHA consistency (aldc.yaml <-> both install scripts) -
+    # --- Check 1: pin policy (the pin is OPTIONAL) ---
+    # The install scripts read url/ref/pinnedCommit from aldc.yaml (single source of
+    # truth), so there is no hardcoded pin to cross-check. When a pin is set it gives
+    # reproducible, evidence-validated runs; when empty, BCQuality tracks the configured
+    # branch/tag and pin coherence is simply skipped.
     pinned = pinned_sha_from_aldc(root)
-    if not pinned:
-        errors.append("aldc.yaml: external.bcquality.pinnedCommit missing or not a 40-hex SHA.")
-
-    # Install scripts hardcode the pin; assert they match aldc.yaml (canonical).
-    for rel in INSTALL_PIN_FILES:
-        script_pin = install_pin(root, rel)
-        if script_pin is None:
-            errors.append(f"{rel}: BCQuality pin assignment not found or not a 40-hex SHA.")
-        elif pinned and script_pin != pinned:
-            errors.append(f"SHA mismatch: aldc.yaml={pinned} but {rel}={script_pin}.")
-        elif pinned:
-            notes.append(f"pinned SHA consistent: {rel} == aldc.yaml")
+    if pinned:
+        notes.append(f"BCQuality pinned to {pinned} (aldc.yaml).")
+    else:
+        notes.append("BCQuality not pinned (aldc.yaml tracks a branch/tag) - pin coherence skipped.")
 
     # --- Resolve the external BCQuality clone (multi-root; no in-repo submodule) ---
     bcq_root = args.bcquality_root or os.environ.get("BCQUALITY_HOME") or home_from_aldc(root)


### PR DESCRIPTION
## Make the BCQuality source configurable (default = canonical upstream)

For the public release, BCQuality no longer hardwires a personal fork. The source is now **configurable** in `aldc.yaml` (single source of truth) and **defaults to the canonical upstream [`microsoft/BCQuality`](https://github.com/microsoft/BCQuality)**.

### Changes
- **`aldc.yaml`** → `external.bcquality`: `url` → `microsoft/BCQuality.git`; new `ref` (branch/tag to track); `pinnedCommit` is now **optional** (empty = track `ref`). Point `url` at your own fork to use it instead.
- **`tools/bcquality/install.{sh,ps1}`**: read `url`/`ref`/`pinnedCommit` from `aldc.yaml` instead of hardcoding; check out the pin if set, else the ref.
- **`tools/bcquality/validate_evidence.py`**: drop the hardcoded-pin cross-check (scripts read config now); pinning optional — **citation resolvability still enforced**.
- **`.github/workflows/bcquality-evidence.yaml`**: clone from `url`/`ref`/`pin` in `aldc.yaml` (handles an empty pin and the upstream's CamelCase URL).
- **docs/bcquality.md, README.md, .github/copilot-instructions.md**: reference the canonical upstream and document "configurable / use your own fork".

### Behaviour
- Default: clone `microsoft/BCQuality` @ `main` (unpinned). Set `pinnedCommit` for reproducible, evidence-validated runs.
- Absent by default — graceful native A–G fallback unchanged.

### Validation
- `aldc-validate` → COMPLIANT, 0 warnings.
- `validate_evidence.py` → PASSED (pin-optional path).
- The `bcquality-evidence` CI on this PR actually clones `microsoft/BCQuality` and runs the validator — a live check of the new config.

### Notes
- `pilotSkills` paths in `aldc.yaml` are left as-is; verify they match the upstream layout when you enable specific review skills.
- Separate small PR; after merge you'll want to **re-package the VSIX** (it bundles `aldc.yaml` + `tools/bcquality/`).

https://claude.ai/code/session_01KDEqho2A9337XJvnTVgGxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDEqho2A9337XJvnTVgGxA)_