### PR TITLE
fix(web): render home two-col text columns as raw HTML (EN + ES)

### DIFF
--- a/docs/index-es.md
+++ b/docs/index-es.md
@@ -61,14 +61,11 @@ hide:
 </div>
 
 <div class="two-col">
-<div class="two-col-text" markdown="1">
+<div class="two-col-text">
 
-**Se instala una vez, desde la Paleta de Comandos.** Ejecuta `AL Collection: Install Toolkit to Workspace`
-y ALDC copia los agentes, skills, instrucciones y configuración en tu proyecto — luego empieza con
-`@AL Architecture & Design Specialist` o `@AL Development Conductor`.
+<p><strong>Se instala una vez, desde la Paleta de Comandos.</strong> Ejecuta <code>AL Collection: Install Toolkit to Workspace</code> y ALDC copia los agentes, skills, instrucciones y configuración en tu proyecto — luego empieza con <code>@AL Architecture &amp; Design Specialist</code> o <code>@AL Development Conductor</code>.</p>
 
-También nuevos: bajo demanda **`@AL Triage`** (diagnóstico reactivo) y **`@Dredd`** (auditor
-independiente) — solo lectura sobre tu código.
+<p>También nuevos: bajo demanda <strong><code>@AL Triage</code></strong> (diagnóstico reactivo) y <strong><code>@Dredd</code></strong> (auditor independiente) — solo lectura sobre tu código.</p>
 
 </div>
 <div class="two-col-visual">
@@ -172,17 +169,18 @@ flowchart TD
 ## Reviews citadas con BCQuality { #bcquality .section-title }
 
 <div class="two-col">
-<div class="two-col-text" markdown="1">
+<div class="two-col-text">
 
-BCQuality es una capa **opcional** que convierte a los agentes de review/auditoría en revisores
-que **citan** — cada hallazgo apunta a un fichero de conocimiento real de Business Central, no a una opinión.
+<p>BCQuality es una capa <strong>opcional</strong> que convierte a los agentes de review/auditoría en revisores que <strong>citan</strong> — cada hallazgo apunta a un fichero de conocimiento real de Business Central, no a una opinión.</p>
 
--   **Fuente configurable.** Por defecto el upstream canónico [microsoft/BCQuality](https://github.com/microsoft/BCQuality); apunta a tu propio fork en `aldc.yaml`.
--   **Consumo externo.** Un clon hermano vía workspace multi-root — nunca compila, nunca contamina tu app.
--   **Se engancha vía `entry.md`.** Los agentes leen la meta-skill y ejecutan lo que despache.
--   **Nunca bloquea.** Ausente por defecto → degradación nativa A–G.
+<ul>
+  <li><strong>Fuente configurable.</strong> Por defecto el upstream canónico <a href="https://github.com/microsoft/BCQuality">microsoft/BCQuality</a>; apunta a tu propio fork en <code>aldc.yaml</code>.</li>
+  <li><strong>Consumo externo.</strong> Un clon hermano vía workspace multi-root — nunca compila, nunca contamina tu app.</li>
+  <li><strong>Se engancha vía <code>entry.md</code>.</strong> Los agentes leen la meta-skill y ejecutan lo que despache.</li>
+  <li><strong>Nunca bloquea.</strong> Ausente por defecto → degradación nativa A–G.</li>
+</ul>
 
-[Lee la guía de BCQuality :material-arrow-right:](../bcquality/){ .md-button }
+<a class="md-button" href="../bcquality/">Lee la guía de BCQuality →</a>
 
 </div>
 <div class="two-col-visual" markdown="1">

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,14 +61,11 @@ hide:
 </div>
 
 <div class="two-col">
-<div class="two-col-text" markdown="1">
+<div class="two-col-text">
 
-**Install once, from the Command Palette.** Run `AL Collection: Install Toolkit to Workspace`
-and ALDC drops the agents, skills, instructions and config into your project — then start
-with `@AL Architecture & Design Specialist` or `@AL Development Conductor`.
+<p><strong>Install once, from the Command Palette.</strong> Run <code>AL Collection: Install Toolkit to Workspace</code> and ALDC drops the agents, skills, instructions and config into your project — then start with <code>@AL Architecture &amp; Design Specialist</code> or <code>@AL Development Conductor</code>.</p>
 
-Also new: on-demand **`@AL Triage`** (reactive diagnosis) and **`@Dredd`** (independent
-auditor) — read-only on your code.
+<p>Also new: on-demand <strong><code>@AL Triage</code></strong> (reactive diagnosis) and <strong><code>@Dredd</code></strong> (independent auditor) — read-only on your code.</p>
 
 </div>
 <div class="two-col-visual">
@@ -172,18 +169,18 @@ flowchart TD
 ## Cited reviews & audits with BCQuality { #bcquality .section-title }
 
 <div class="two-col">
-<div class="two-col-text" markdown="1">
+<div class="two-col-text">
 
-BCQuality is an **optional** layer that turns the review/audit agents into **citing**
-reviewers — every finding points to a real Business Central knowledge file, not just an
-opinion.
+<p>BCQuality is an <strong>optional</strong> layer that turns the review/audit agents into <strong>citing</strong> reviewers — every finding points to a real Business Central knowledge file, not just an opinion.</p>
 
--   **Configurable source.** Defaults to the canonical upstream [microsoft/BCQuality](https://github.com/microsoft/BCQuality); point it at your own fork in `aldc.yaml`.
--   **Consumed externally.** A sibling clone via multi-root workspace — never compiled, never pollutes your app.
--   **Hooks in via `entry.md`.** Agents read the meta-skill and run whatever it dispatches.
--   **Never blocks.** Absent by default → graceful native A–G fallback.
+<ul>
+  <li><strong>Configurable source.</strong> Defaults to the canonical upstream <a href="https://github.com/microsoft/BCQuality">microsoft/BCQuality</a>; point it at your own fork in <code>aldc.yaml</code>.</li>
+  <li><strong>Consumed externally.</strong> A sibling clone via multi-root workspace — never compiled, never pollutes your app.</li>
+  <li><strong>Hooks in via <code>entry.md</code>.</strong> Agents read the meta-skill and run whatever it dispatches.</li>
+  <li><strong>Never blocks.</strong> Absent by default → graceful native A–G fallback.</li>
+</ul>
 
-[Read the BCQuality guide :material-arrow-right:](bcquality/){ .md-button }
+<a class="md-button" href="bcquality/">Read the BCQuality guide →</a>
 
 </div>
 <div class="two-col-visual" markdown="1">


### PR DESCRIPTION
## What

The home page's **install band** and **BCQuality section** rendered literal
markdown on the live site — `**Install once...**` showed raw asterisks and the
BCQuality bullets showed raw `-`/`**`/`` ` `` — in **both** the EN (`index.md`)
and ES (`index-es.md`) homes.

## Why

Those text columns used `markdown="1"` while nested inside a raw
`<div class="two-col">` wrapper. Material's `md_in_html` does not re-parse
markdown in that nested context, so the source was emitted verbatim. The
adjacent **visual** columns work because they only wrap fenced code
(mermaid / `text`), which superfences handles regardless.

## Fix

Author the affected text columns as **raw HTML** (`<p>`, `<strong>`, `<code>`,
`<ul><li>`, `<a class="md-button">`), matching the already-working
"What's ALDC" section on the same page. Visual columns keep `markdown="1"`.

## Verification

Built locally (non-strict, minify dropped) and asserted on the rendered HTML:

| check | EN | ES |
|---|---|---|
| literal `**Install once` / `**Se instala` | 0 | 0 |
| `<strong>Install once` / `<strong>Se instala` | 1 | 1 |
| BCQuality `<li><strong>…` list item | 1 | 1 |
| `md-button` "Read/Lee the BCQuality guide" | 1 | 1 |

No leftover literal markdown anywhere in either home. Docs-only change.

https://claude.ai/code/session_01KDEqho2A9337XJvnTVgGxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDEqho2A9337XJvnTVgGxA)_