### PR TITLE
docs(web): drop the ~ before 31% on the home (EN + ES)

### DIFF
--- a/docs/index-es.md
+++ b/docs/index-es.md
@@ -47,7 +47,7 @@ hide:
 
     ---
 
-    Entrypoint always-on **~31% más ligero**, globs de instrucciones estrechos por tipo de
+    Entrypoint always-on **31% más ligero**, globs de instrucciones estrechos por tipo de
     objeto, y contexto curado pasado a los subagentes. Las mismas capacidades — menos tokens en cada petición.
 
 -   :material-book-search-outline: &nbsp; **Reviews y auditorías citadas con BCQuality**

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ hide:
 
     ---
 
-    A **~31% lighter** always-on entrypoint, narrow per-object instruction globs, and
+    A **31% lighter** always-on entrypoint, narrow per-object instruction globs, and
     curated context passed to subagents. Same capabilities — fewer tokens on every request.
 
 -   :material-book-search-outline: &nbsp; **Cited reviews & audits with BCQuality**


### PR DESCRIPTION
## What

Drops the `~` before **31%** on the home (EN + ES): "~31% lighter" → "**31% lighter**" / "**31% más ligero**".

## Why

Follow-up to #55. The tilde commit was pushed *after* #55 was already squash-merged, so it never reached `main`. This re-applies it cleanly on a single-commit branch off `main`.

## Scope

Docs-only. 2 files, 2 lines.

https://claude.ai/code/session_01KDEqho2A9337XJvnTVgGxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDEqho2A9337XJvnTVgGxA)_