### PR TITLE
style(web): promote 4.1.0 in the hero banner, demote the workshop link (EN + ES)

### DIFF
--- a/docs/index-es.md
+++ b/docs/index-es.md
@@ -8,9 +8,9 @@ hide:
 
 <div class="hero">
 
-<a class="hero-banner" href="https://javiarmesto.github.io/aldc-workshop/en/" target="_blank" rel="noopener">
+<a class="hero-banner" href="#novedades">
   <span class="hero-banner__badge">NUEVO</span>
-  <span class="hero-banner__text">El Workshop público de ALDC ya está disponible — práctico, gratuito, online</span>
+  <span class="hero-banner__text">ALDC 4.1.0 — entrypoint 31% más ligero + reviews citadas con BCQuality</span>
   <span class="hero-banner__arrow">→</span>
 </a>
 
@@ -25,6 +25,8 @@ hide:
   <a class="md-button" href="../al-development/">Abre la guía de la colección</a>
   <a class="md-button" href="https://github.com/javiarmesto/ALDC-AL-Development-Collection">GitHub</a>
 </div>
+
+<p class="hero-subnote">Gratuito y práctico: <a href="https://javiarmesto.github.io/aldc-workshop/en/" target="_blank" rel="noopener">Workshop público de ALDC →</a></p>
 
 <div class="hero-pills">
   <span class="pill"><b>4</b> públicos + <b>2</b> bajo demanda</span>

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@ hide:
 
 <div class="hero">
 
-<a class="hero-banner" href="https://javiarmesto.github.io/aldc-workshop/en/" target="_blank" rel="noopener">
+<a class="hero-banner" href="#whats-new">
   <span class="hero-banner__badge">NEW</span>
-  <span class="hero-banner__text">Public ALDC Workshop is live — hands-on, free, online</span>
+  <span class="hero-banner__text">ALDC 4.1.0 — 31% lighter entrypoint + BCQuality-cited reviews</span>
   <span class="hero-banner__arrow">→</span>
 </a>
 
@@ -25,6 +25,8 @@ hide:
   <a class="md-button" href="al-development/">Open the collection guide</a>
   <a class="md-button" href="https://github.com/javiarmesto/ALDC-AL-Development-Collection">GitHub</a>
 </div>
+
+<p class="hero-subnote">Free, hands-on: <a href="https://javiarmesto.github.io/aldc-workshop/en/" target="_blank" rel="noopener">Public ALDC Workshop →</a></p>
 
 <div class="hero-pills">
   <span class="pill"><b>4</b> public + <b>2</b> on-demand agents</span>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -464,6 +464,20 @@ body,
 }
 .hero .md-button:hover { transform: translateY(-2px); }
 
+/* Demoted workshop link — small, muted, sits below the primary CTAs */
+.hero-subnote {
+  margin: 1rem 0 0;
+  font-size: 0.82rem;
+  color: var(--b44-stone);
+}
+.hero-subnote a {
+  font-weight: 700;
+  color: var(--b44-sunset);
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.15s ease;
+}
+.hero-subnote a:hover { border-bottom-color: var(--b44-sunset); }
+
 .hero-pills {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## What

The hero-promo commit that slipped past #57's squash-merge. Re-applied cleanly on a single-commit branch off `main`.

- **Top banner promotes 4.1.0.** Announces *ALDC 4.1.0 — 31% lighter entrypoint + BCQuality-cited reviews* and jumps to the *What's new* band (`#whats-new` / `#novedades`) instead of the workshop.
- **Workshop demoted.** Moves to a small, muted `.hero-subnote` link below the primary CTAs — still present, less prominent.

EN + ES.

## Why a new PR

#57 was squash-merged at the accent commit, *before* this hero-promo push landed on the branch — so it never reached `main` (same race as #56 vs #55).

## Files

- `docs/index.md` / `docs/index-es.md` — banner → 4.1.0, workshop subnote.
- `docs/stylesheets/extra.css` — `.hero-subnote`.

## Verification

Cherry-picked onto `main` cleanly. Banner → `#whats-new`/`#novedades` and `.hero-subnote` present in both languages. Docs/CSS only.

https://claude.ai/code/session_01KDEqho2A9337XJvnTVgGxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDEqho2A9337XJvnTVgGxA)_