### PR TITLE
fix(installer): re-point bare framework paths to the target dir on install

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -160,7 +160,8 @@ function rewriteRuntimePaths(dir, relTarget) {
   //  (?<![\w./-]) : not preceded by a word/path char -> skips ../bcquality/skills,
   //                 <home>/skills, skill-agent-instructions/, and .github/skills (no double-prefix)
   //  (?<!\]\()    : not a markdown link target like ](skills/...)
-  const re = new RegExp(`(?<![\\w./-])(?<!\\]\\()(${RUNTIME_FOLDERS.join('|')})/`, 'g');
+  //  capture the first path component after the folder so we can verify it resolves.
+  const re = new RegExp(`(?<![\\w./-])(?<!\\]\\()(${RUNTIME_FOLDERS.join('|')})/([A-Za-z0-9._*<>{}-]*)`, 'g');
   let files = 0, refs = 0;
   const walk = (d) => {
     for (const item of fs.readdirSync(d)) {
@@ -169,7 +170,17 @@ function rewriteRuntimePaths(dir, relTarget) {
       if (!isRuntimePrimitive(item)) continue;
       const before = fs.readFileSync(p, 'utf8');
       let n = 0;
-      const after = before.replace(re, (_m, folder) => { n++; return `${relTarget}/${folder}/`; });
+      const after = before.replace(re, (m, folder, first) => {
+        // Determinism guard: only re-point when the result provably resolves
+        // under the toolkit. A glob/placeholder (skills/<name>/, instructions/al-*)
+        // can't be checked, but its folder is real, so prefix it. A concrete first
+        // component that does NOT exist (e.g. the external BCQuality `skills/read.md`)
+        // is left untouched — we never invent a path the agent can't open.
+        const isGlobOrBare = first === '' || /[*<>{}]/.test(first);
+        if (!isGlobOrBare && !fs.existsSync(path.join(dir, folder, first))) return m;
+        n++;
+        return `${relTarget}/${m}`;
+      });
       if (n > 0) { fs.writeFileSync(p, after, 'utf8'); files++; refs += n; }
     }
   };

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -138,6 +138,45 @@ function copyDir(src, dst, force = false, depth = 0) {
   return { copied, skipped };
 }
 
+// Framework folders that end up UNDER the target dir after install. The agent
+// read tools resolve paths relative to the repo ROOT, so a bare reference like
+// `skills/...` in a primitive's prose points at <root>/skills (which does not
+// exist when the toolkit was installed into .github/). Re-point those bare,
+// root-relative references at the target dir so they resolve in the consumer.
+// External paths (../bcquality/...), already-prefixed paths and markdown link
+// targets are deliberately left untouched.
+const RUNTIME_FOLDERS = ['skills', 'instructions', 'prompts', 'agents', 'docs'];
+
+// Only files an agent reads at runtime carry these path references. Skip the
+// always-on entrypoint, the index and READMEs: their `skills/` / `docs/` tokens
+// are illustrative (directory trees, prose) or intentionally relative links.
+function isRuntimePrimitive(name) {
+  if (name === 'copilot-instructions.md' || name === 'index.md' || name === 'README.md') return false;
+  return name.endsWith('.agent.md') || name.endsWith('.prompt.md') ||
+         name.endsWith('.instructions.md') || name === 'SKILL.md';
+}
+
+function rewriteRuntimePaths(dir, relTarget) {
+  //  (?<![\w./-]) : not preceded by a word/path char -> skips ../bcquality/skills,
+  //                 <home>/skills, skill-agent-instructions/, and .github/skills (no double-prefix)
+  //  (?<!\]\()    : not a markdown link target like ](skills/...)
+  const re = new RegExp(`(?<![\\w./-])(?<!\\]\\()(${RUNTIME_FOLDERS.join('|')})/`, 'g');
+  let files = 0, refs = 0;
+  const walk = (d) => {
+    for (const item of fs.readdirSync(d)) {
+      const p = path.join(d, item);
+      if (fs.statSync(p).isDirectory()) { walk(p); continue; }
+      if (!isRuntimePrimitive(item)) continue;
+      const before = fs.readFileSync(p, 'utf8');
+      let n = 0;
+      const after = before.replace(re, (_m, folder) => { n++; return `${relTarget}/${folder}/`; });
+      if (n > 0) { fs.writeFileSync(p, after, 'utf8'); files++; refs += n; }
+    }
+  };
+  walk(dir);
+  return { files, refs };
+}
+
 /**
  * Copy a single file. Returns true if copied.
  */
@@ -275,6 +314,17 @@ async function install(opts) {
     log('  collections/ not found (optional)', C.dim);
   }
 
+  // 2b. Normalize root-relative framework paths in the copied runtime primitives
+  //     to the target dir (e.g. `skills/` -> `.github/skills/`). Only needed when
+  //     installing into a subdir; a root install (relTarget ".") is already correct.
+  const relTarget = path.relative(projectDir, targetDir).replace(/\\/g, '/') || '.';
+  if (relTarget !== '.') {
+    header('Normalizing runtime paths');
+    const r = rewriteRuntimePaths(targetDir, relTarget);
+    if (r.files) ok(`Re-pointed ${r.refs} path ref(s) in ${r.files} file(s) to "${relTarget}/"`);
+    else log('  no bare framework paths to rewrite', C.dim);
+  }
+
   // 3. Copy aldc.yaml to project root and update toolkitRoot
   header('Installing Configuration');
   const aldcYamlDst = path.join(projectDir, 'aldc.yaml');
@@ -285,7 +335,7 @@ async function install(opts) {
   )) {
     totalCopied++;
     // Update toolkitRoot to match the target directory relative to project root
-    const relTarget = path.relative(projectDir, targetDir).replace(/\\/g, '/') || '.';
+    // (relTarget computed above in step 2b)
     if (relTarget !== '.') {
       let yamlContent = fs.readFileSync(aldcYamlDst, 'utf8');
       yamlContent = yamlContent.replace(/^toolkitRoot:\s*"\."/m, `toolkitRoot: "${relTarget}"`);


### PR DESCRIPTION
## Problema

Auditando la convención de rutas entre repos consumidores se detectó que tras **instalar** ALDC, las rutas internas de los agentes rompían. Causa raíz: el instalador copia el toolkit al `.github/` del consumidor y reescribe `toolkitRoot`, **pero no reescribía las rutas root-relative dentro de la prosa de las primitivas**. La herramienta de lectura del agente resuelve relativo a la **raíz del repo**, así que post-install `.github/agents/*.agent.md` con `` `skills/...` `` o `` `docs/templates/...` `` apuntaba a `<raíz>/skills` (inexistente). Todas las rutas del framework rompían en consumidores instalados bajo `.github/`.

> El repo **fuente** usa rutas bare a propósito (su layout es de raíz, donde resuelven bien); por eso el arreglo va en el **install-time**, no en la prosa. ALDC-Forge (layout `.github/`-based) ya estaba unificado y no necesitaba cambios.

## Fix

Paso de normalización post-copia (**2b**) que re-apunta las referencias bare a las carpetas del framework (`skills/ instructions/ prompts/ agents/ docs/`) al target dir, p. ej. `skills/` → `.github/skills/`.

- **Acotado** a primitivas que el agente lee en runtime: `*.agent.md`, `*.prompt.md`, `*.instructions.md`, `SKILL.md`.
- **Excluye** `copilot-instructions.md`, `index.md`, `README.md` (sus tokens `skills/`/`docs/` son árboles de directorio ilustrativos o enlaces markdown relativos — respeta el paso 4 de la auditoría).
- **Guardas** (lookbehind): no toca rutas externas (`../bcquality/...`), ni ya-prefijadas (sin `.github/.github`), ni targets de enlaces markdown `](...)`.
- Solo actúa al instalar en subdirectorio; una instalación en raíz ya es correcta.

## Verificación

Instalación simulada en `.github/`:
- **41** refs reescritas en **12** ficheros.
- `grep` de aceptación del usuario sobre el consumidor → **0** referencias bare.
- Todos los destinos reescritos (`.github/docs/templates/…`, `.github/skills/…`, …) **resuelven en disco**.
- Externos (`../bcquality/skills/`, `<home>/skills/`) y el árbol de `copilot-instructions.md` **intactos**.
- Repo fuente: solo cambia `scripts/install.js`; la prosa de los agentes no se toca.

## Pendiente (fuera de este PR)

El instalador del **VSIX** (`extension.js`, proyecto aparte) tiene el mismo gap y necesita el equivalente — se entrega el snippet por separado.

https://claude.ai/code/session_01KDEqho2A9337XJvnTVgGxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDEqho2A9337XJvnTVgGxA)_