### PR TITLE
style(al-conductor): lightweight, token-conscious progress format

### DIFF
--- a/agents/al-conductor.agent.md
+++ b/agents/al-conductor.agent.md
@@ -57,24 +57,28 @@ Specialized domains (MEDIUM/HIGH):
 
 ## Visual Progress Format (used throughout)
 
-All phases use this standard visual format. When a subagent is running:
+Render progress **lightweight** — do not redraw heavy ASCII boxes; they cost tokens
+on every phase. Default to this two-line format per phase:
 
 ```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-🎭 AL CONDUCTOR ORCHESTRATION
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-┌─ Phase {N}/{Total}: {Phase Name} ─────────────────────┐
-│ {icon} {Subagent Name}                      [RUNNING] │
-│ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ...%      │
-│ Status: {Current action}                              │
-└────────────────────────────────────────────────────────┘
+**🧙 Phase {N}/{Total} · {Phase Name}**
+{icon} {Subagent} · `[RUNNING]` — {Current action}
 ```
 
-Icons: 🔍 Planning, 💻 Implementation, ✅ Review, 🎭 Conductor, 🚦 Checkpoint, 💡 Recommendation.
+On completion, swap `[RUNNING]` → `[COMPLETE]` and replace the action with a one-line
+deliverables summary.
+
+At **checkpoints / milestones** (HITL pauses, phase gates) you may use the richer card:
+
+```
+**🧙 AL Conductor — Phase {N}/{Total}: {Phase Name}**
+> {icon} **{Subagent}** `[RUNNING]`
+> `▰▰▰▰▱▱▱▱▱▱` {N}/{Total} · {Current action}
+```
+
+Icons: 🔍 Planning, 💻 Implementation, ✅ Review, 🧙 Conductor, 🚦 Checkpoint, 💡 Recommendation.
 Status flags: `[RUNNING]`, `[COMPLETE]`, `[WAITING]`, `[FAILED]`.
-
-After completion, swap `[RUNNING]` for `[COMPLETE]`, show `100%` and add deliverables summary.
+Progress is by **phase** (N/Total), a real value — never invent per-task percentages.
 
 ---
 
@@ -611,7 +615,7 @@ Cross-check implement-subagent's "### Skills Loaded" against review-subagent's "
 
 **Request**: "Add email validation to Customer table"
 
-1. 🎭 Conductor activates → invokes 🔍 al-planning-subagent
+1. 🧙 Conductor activates → invokes 🔍 al-planning-subagent
 2. Planning returns findings (Table 18, `OnBeforeValidateEvent` available, AL-Go validated)
 3. Conductor drafts plan (3 phases: Test Setup → Implement Validation → Integration)
 4. Presents open questions (empty emails allowed? case-sensitive? .NET Regex vs custom?)

--- a/packages/foundation/agents/al-conductor.agent.md
+++ b/packages/foundation/agents/al-conductor.agent.md
@@ -57,24 +57,28 @@ Specialized domains (MEDIUM/HIGH):
 
 ## Visual Progress Format (used throughout)
 
-All phases use this standard visual format. When a subagent is running:
+Render progress **lightweight** — do not redraw heavy ASCII boxes; they cost tokens
+on every phase. Default to this two-line format per phase:
 
 ```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-🎭 AL CONDUCTOR ORCHESTRATION
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-┌─ Phase {N}/{Total}: {Phase Name} ─────────────────────┐
-│ {icon} {Subagent Name}                      [RUNNING] │
-│ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ...%      │
-│ Status: {Current action}                              │
-└────────────────────────────────────────────────────────┘
+**🧙 Phase {N}/{Total} · {Phase Name}**
+{icon} {Subagent} · `[RUNNING]` — {Current action}
 ```
 
-Icons: 🔍 Planning, 💻 Implementation, ✅ Review, 🎭 Conductor, 🚦 Checkpoint, 💡 Recommendation.
+On completion, swap `[RUNNING]` → `[COMPLETE]` and replace the action with a one-line
+deliverables summary.
+
+At **checkpoints / milestones** (HITL pauses, phase gates) you may use the richer card:
+
+```
+**🧙 AL Conductor — Phase {N}/{Total}: {Phase Name}**
+> {icon} **{Subagent}** `[RUNNING]`
+> `▰▰▰▰▱▱▱▱▱▱` {N}/{Total} · {Current action}
+```
+
+Icons: 🔍 Planning, 💻 Implementation, ✅ Review, 🧙 Conductor, 🚦 Checkpoint, 💡 Recommendation.
 Status flags: `[RUNNING]`, `[COMPLETE]`, `[WAITING]`, `[FAILED]`.
-
-After completion, swap `[RUNNING]` for `[COMPLETE]`, show `100%` and add deliverables summary.
+Progress is by **phase** (N/Total), a real value — never invent per-task percentages.
 
 ---
 
@@ -611,7 +615,7 @@ Cross-check implement-subagent's "### Skills Loaded" against review-subagent's "
 
 **Request**: "Add email validation to Customer table"
 
-1. 🎭 Conductor activates → invokes 🔍 al-planning-subagent
+1. 🧙 Conductor activates → invokes 🔍 al-planning-subagent
 2. Planning returns findings (Table 18, `OnBeforeValidateEvent` available, AL-Go validated)
 3. Conductor drafts plan (3 phases: Test Setup → Implement Validation → Integration)
 4. Presents open questions (empty emails allowed? case-sensitive? .NET Regex vs custom?)


### PR DESCRIPTION
## Qué

Rediseña el bloque **Visual Progress Format** de `al-conductor` para un look más actual y **token-consciente** (se redibuja en cada fase).

**Antes:** cabecera con reglas `━━━…` de 55 chars repetidas, caja `┌─│└` de ancho fijo con relleno, y barra `…%` **inventada** (el subagente no reporta % real). ~120-150 tokens por render.

**Ahora — dos formatos:**

- **A (por defecto, ~15-20 tokens/fase):**
  ```
  **🧙 Phase {N}/{Total} · {Phase Name}**
  {icon} {Subagent} · `[RUNNING]` — {Current action}
  ```
- **B (checkpoints/hitos):**
  ```
  **🧙 AL Conductor — Phase {N}/{Total}: {Phase Name}**
  > {icon} **{Subagent}** `[RUNNING]`
  > `▰▰▰▰▱▱▱▱▱▱` {N}/{Total} · {Current action}
  ```

## Detalles

- Avance por **fase real (N/Total)**, no un porcentaje inventado.
- Emoji del conductor **🎭 → 🧙** en todo el agente (bloque, leyenda de iconos, y la línea "Conductor activates").
- Flags de estado y leyenda de iconos se mantienen.
- Root + `packages/foundation/` (idénticos).

## Por qué PR nueva

Es continuación de #60 (ya mergeada). El commit del formato se empujó tras el merge, así que no llegó a `main`; aquí va limpio sobre `main`.

https://claude.ai/code/session_01KDEqho2A9337XJvnTVgGxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDEqho2A9337XJvnTVgGxA)_