### PR TITLE
perf(triage): mirror the #2 "don't re-read in context" guard into al-triage

### DIFF
--- a/agents/al-triage.agent.md
+++ b/agents/al-triage.agent.md
@@ -34,6 +34,8 @@ Load **`skill-debug`** first — it owns the method (debugging strategy, data-fl
 6. **Diagnose.** Write `.github/plans/<issue-kebab-case>-diagnosis.md` using **skill-debug's Step 4 template**, plus two fields it under-specifies: **Blast radius** (from step 4) and **Citations** (BCQuality `file:line` from step 5, when present). Recommend a **minimal permanent fix** at the root cause; add a **short-term mitigation/hotfix** only when the permanent fix is risky or slow to ship.
 7. **HITL gate + handoff.** PAUSE and present the diagnosis + proposed fix. On approval, hand the fix to **`@al-developer`** (simple) or **`@al-conductor`** (multi-phase refactor). You do not edit code.
 
+> **Don't re-read a file already in context.** This loop revisits the same artifacts across steps — the suspect `.al`, the changed-vs-`main` diff, `aldc.yaml`, and `<home>/entry.md` get touched at localize, root-cause, blast-radius, and diagnose. Read each **once** and reuse it; never `read_file` the same path twice within a diagnosis. (Same discipline the review/audit agents apply — symbol *discovery* is still your job here; re-*reading* what you already hold is the waste.)
+
 ## Three inversions vs the greenfield (conductor) loop
 
 - **Reproduce-first, not design-first** — no fix without a reproduction or evidence-backed root cause.

--- a/packages/foundation/agents/al-triage.agent.md
+++ b/packages/foundation/agents/al-triage.agent.md
@@ -34,6 +34,8 @@ Load **`skill-debug`** first — it owns the method (debugging strategy, data-fl
 6. **Diagnose.** Write `.github/plans/<issue-kebab-case>-diagnosis.md` using **skill-debug's Step 4 template**, plus two fields it under-specifies: **Blast radius** (from step 4) and **Citations** (BCQuality `file:line` from step 5, when present). Recommend a **minimal permanent fix** at the root cause; add a **short-term mitigation/hotfix** only when the permanent fix is risky or slow to ship.
 7. **HITL gate + handoff.** PAUSE and present the diagnosis + proposed fix. On approval, hand the fix to **`@al-developer`** (simple) or **`@al-conductor`** (multi-phase refactor). You do not edit code.
 
+> **Don't re-read a file already in context.** This loop revisits the same artifacts across steps — the suspect `.al`, the changed-vs-`main` diff, `aldc.yaml`, and `<home>/entry.md` get touched at localize, root-cause, blast-radius, and diagnose. Read each **once** and reuse it; never `read_file` the same path twice within a diagnosis. (Same discipline the review/audit agents apply — symbol *discovery* is still your job here; re-*reading* what you already hold is the waste.)
+
 ## Three inversions vs the greenfield (conductor) loop
 
 - **Reproduce-first, not design-first** — no fix without a reproduction or evidence-backed root cause.


### PR DESCRIPTION
## Qué

Continuación de #66 (mergeado). Lleva **solo el patrón #2** ("no re-leer lo ya en contexto") a **`al-triage`**, que no estaba en el lote original.

`al-triage` reincide en la misma trampa: su bucle de 7 pasos (localize → root-cause → blast-radius → diagnose) toca el mismo `.al` sospechoso, el diff vs `main`, `aldc.yaml` y `entry.md` en varios pasos, sin nada que impida re-`read_file` la misma ruta 3-4× por diagnóstico. Una guardia de una línea cierra eso.

## Por qué solo #2

Triage es un **diagnóstico lineal de una pasada**, no un looper multi-leaf como review/dredd. Por eso los otros patrones de #66 **no aplican estructuralmente**:

| Patrón #66 | ¿Aplica a triage? | Motivo |
|---|:---:|---|
| **#2** no re-leer en contexto | ✅ | Su bucle revisita los mismos artefactos en varios pasos |
| **#3** cargar skill/símbolos una vez por leaf | ❌ | No itera sobre leaves; consulta BCQuality una vez, scoped |
| **#4** consumir lista de subscribers | ❌ | No tiene conductor encima; descubrir símbolos **es su trabajo** |
| **#5** firmas inline | ❌ | No produce código ni RETURN a un reviewer |

Meter #3/#4 aquí sería cargo-culting — la guardia aclara explícitamente que el *descubrimiento* de símbolos sigue siendo su trabajo; lo que se elimina es re-*leer* lo que ya tiene.

## Alcance

- **Prosa, una línea.** Sin cambios de lógica/flujo.
- Espejado: `agents/` + `packages/foundation/agents/`.
- `docs/agents/al-triage.agent.md` se deja como la ficha curada (mismo criterio que #66, que tampoco tocó `docs/agents`).

https://claude.ai/code/session_01KDEqho2A9337XJvnTVgGxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDEqho2A9337XJvnTVgGxA)_