### PR TITLE
feat(orchestration): actually load instructions + skills in agent runtime

### DIFF
--- a/agents/al-architect.agent.md
+++ b/agents/al-architect.agent.md
@@ -210,7 +210,7 @@ For **LOW complexity**: skip architect, use `al-spec.create` → `@al-developer`
 
 ## Domain Skills
 
-This agent works with the following skills from `.github/skills/`. Copilot loads them automatically when relevant:
+This agent draws on these skills from `.github/skills/`. They are **not** auto-loaded — **load the `SKILL.md` on demand** (read it) when the design enters that domain:
 
 - **skill-api** — designing API pages, OData endpoints, integration strategy
 - **skill-events** — designing event-driven architecture, publishers/subscribers
@@ -218,7 +218,7 @@ This agent works with the following skills from `.github/skills/`. Copilot loads
 - **skill-copilot** — designing Copilot/AI feature architecture
 - **skill-pages** — designing page layouts, UX patterns, navigation
 
-To explicitly invoke a skill, use: `/skill-api`, `/skill-events`, etc.
+**Load = read the `SKILL.md`.** Naming a skill without reading it is not loading it.
 
 ## Skills Evidencing
 

--- a/agents/al-conductor.agent.md
+++ b/agents/al-conductor.agent.md
@@ -164,10 +164,10 @@ Invoke **AL Implementation Subagent** (💻) via `#runSubagent` with:
 - Test requirements following AL-Go structure (`test/` project)
 - AL-specific patterns (SetLoadFields, error handling, naming ≤26 chars)
 - Explicit TDD instruction: tests first (failing), minimal code, tests pass, lint/format
-- Domain skills to load from `.github/skills/` based on phase domain
+- **The 7 always-on instruction micro-rules inline** + **domain skill hints** for this phase (per §"Passing Context to Subagents" — the subagent loads the `SKILL.md` on demand, not you)
 - Instruction: work autonomously, only ask user on critical implementation decisions
 - **NOT** to proceed to next phase or write completion files (you handle this)
-- **RETURN** structured summary: objects created, **event subscribers (exact base object + event name + signature)**, tests created, build status, issues, skills loaded
+- **RETURN** structured summary: objects created, **event subscribers (exact base object + event name + signature)**, tests created, build status, issues, and the **symbolic skills line** (`📐 instr ✓ · 🧠 skill-x·tag`)
 
 **⛔ TDD ENFORCEMENT**: If subagent returns code without tests, REJECT the phase result and re-invoke with explicit TDD instruction. **Zero tests = phase FAILED.**
 
@@ -668,6 +668,8 @@ Instead, **pass phase-relevant excerpts inline** in the `#runSubagent` instructi
 - **Architecture decisions** — only the decisions/constraints this phase must honor (e.g. "use CalcSums, not a FlowField"; "publish IntegrationEvent X"), not the full document.
 - **Test-plan excerpt** — only the tests scoped to this phase.
 - **Memory** — only the cross-session decisions that bear on this phase.
+- **The 7 always-on instruction micro-rules** (`instructions/al-*.instructions.md`) — read them **once** at run start and pass them inline to **every** code-touching subagent (implement, review). They are tiny (~1.3K tokens total) hard-rule baselines, and the `applyTo` auto-apply does **not** fire in subagent runtime (no attached files) — so injecting them is the only way they take effect. **Not optional, not per-domain**: pass all seven on every code phase. They are the floor; the depth lives in the skills they point to.
+- **Domain skill *hints*** — name the skills likely relevant to this phase's domain (e.g. `skill-events` for an event phase). These are **hints, not mandates**: the subagent loads the `SKILL.md` on demand when it enters the domain, and may load a skill you didn't hint if it finds it needs one.
 
 Tell the subagent: **the excerpts are authoritative for this phase; read the full file under `.github/plans/` only if a referenced detail is missing from the excerpt.** Always include the file path so that escape hatch works. This trades a few KB in the invocation prompt for eliminating 5–8 redundant `read_file` round-trips per subagent invocation.
 

--- a/agents/al-conductor.agent.md
+++ b/agents/al-conductor.agent.md
@@ -504,11 +504,11 @@ DO NOT proceed past these points without explicit user confirmation.
 
 ## Domain Skills
 
-This agent works with skills from `.github/skills/`. Copilot loads them automatically when relevant:
+This agent draws on skills from `.github/skills/`. They are **not** auto-loaded — **load the `SKILL.md` on demand** (read it) when you need it:
 
 - **skill-testing** — orchestrating TDD cycles when test strategy is needed
 
-Explicit invocation: `/skill-testing`.
+(Per phase, the implement/review subagents load their own domain skills — you pass them as *hints*, see §"Passing Context to Subagents".)
 
 ## Skills Evidencing
 

--- a/agents/al-implement-subagent.agent.md
+++ b/agents/al-implement-subagent.agent.md
@@ -80,7 +80,7 @@ Before writing any test code:
 
 ### Object & Pattern Reference
 
-For object-creation patterns, naming, performance and error-handling rules, **rely on the active framework**: the matching micro-instructions in `.github/instructions/al-*` auto-load when you edit `.al` files, and the relevant skill (`skill-events`, `skill-pages`, `skill-permissions`, `skill-performance`, `skill-api`, `skill-copilot`) provides full examples and patterns. Do not invent or duplicate those rules in your responses; load the skill and follow it.
+For object-creation patterns, naming, performance and error-handling rules, **rely on the framework — but know how it reaches you here.** The Conductor passes the **always-on instruction micro-rules inline** in your invocation (the `applyTo` auto-apply does **not** fire in subagent runtime — don't wait for it); treat them as in effect for the whole phase. For the **detail**, each instruction points to its skill: when you enter that domain (`skill-events`, `skill-pages`, `skill-permissions`, `skill-performance`, `skill-api`, `skill-copilot`), **load the skill — read its `SKILL.md` — and follow it**, including a skill the Conductor didn't hint if you find you need it. Do not invent or duplicate the rules; load the skill.
 
 ### Test Patterns (Given/When/Then)
 
@@ -134,8 +134,7 @@ end;
 
 ## Domain Skills
 
-This agent works with the following skills from .github/skills/.
-Copilot loads them automatically when relevant to the task:
+These skills live in `.github/skills/`. They are **not** auto-loaded in subagent runtime — **you load them on demand** (read the `SKILL.md`) when the phase enters the matching domain. The Conductor hints the likely ones; load the one you actually need (and any other you discover you need):
 
 - **skill-api** — When creating API pages, OData endpoints, HttpClient integrations
 - **skill-events** — When implementing event subscribers/publishers
@@ -144,33 +143,25 @@ Copilot loads them automatically when relevant to the task:
 - **skill-copilot** — When implementing Copilot/AI features
 - **skill-testing** — When designing tests, Given/When/Then patterns
 
-To explicitly invoke a skill, use: /skill-api, /skill-testing, etc.
+**Load = read the `SKILL.md`.** Naming a skill without reading it is not loading it.
 
 </domain_skills>
 
-## Skills Evidencing
+## Skills Evidencing (symbolic)
 
-In the **Phase Implementation Summary** (see Output Format), you MUST declare which skills you loaded and which specific pattern you applied from each.
+In the **Phase Implementation Summary**, emit **one symbolic line** — a cheap coverage trace, not a table:
 
-**Format — "### Skills Loaded" in every Phase Summary:**
-
-```markdown
-### Skills Loaded
-- skill-api — Applied: ODataKeyFields, APIPublisher conventions
-- skill-permissions — Applied: PermissionSet generation pattern
+```
+📐 instr ✓ · 🧠 skill-events·EventSub+TryFunc · skill-performance·SetLoadFields
 ```
 
-If no domain skills were required for the phase:
-
-```markdown
-### Skills Loaded
-No domain skills required for this phase.
-```
+- `📐 instr ✓` — the always-on instruction baseline (passed inline by the Conductor) was in effect.
+- `🧠 <skill>·<1–3-word pattern tag>` — one token per skill you **actually read and applied**, with the concrete pattern.
+- None: `📐 instr ✓ · 🧠 none`.
 
 **Rules:**
-- ONE entry per skill loaded (folder name, not file), with the concrete pattern/workflow used
-- This section is MANDATORY — the Conductor uses it to verify skill coverage
-- If you loaded a skill but did not apply any pattern from it, state why (e.g., "skill-events — Loaded but no event patterns applicable to enum-only phase")
+- Only list a skill you genuinely **read** (`SKILL.md`) **and applied** — this line is the Conductor's coverage signal; padding it with unread skills is the evidencing-theater we are removing.
+- Folder name, not file. One token per skill.
 
 <common_al_test_pitfalls>
 
@@ -276,11 +267,8 @@ After completing a phase, return this structured summary to the Conductor:
 ```markdown
 ## Phase {N} Implementation Summary
 
-### Skills Loaded
-- skill-api — Applied: ODataKeyFields, APIPublisher conventions
-- skill-permissions — Applied: PermissionSet generation pattern
-*(List each skill loaded and the specific pattern applied from it.
-If no domain skills were required for this phase: "No domain skills required for this phase.")*
+📐 instr ✓ · 🧠 skill-events·EventSub+TryFunc · skill-performance·SetLoadFields
+*(One symbolic line — only skills you actually read and applied, each with a 1–3 word pattern tag. None → `📐 instr ✓ · 🧠 none`.)*
 
 ### Objects Created
 - {Type} {ID} "{Name}" — {purpose}

--- a/agents/al-presales.agent.md
+++ b/agents/al-presales.agent.md
@@ -827,12 +827,9 @@ await createFile('Technical_PreSales/customer-loyalty-system/00-executive-summar
 
 ## Domain Skills
 
-This agent works with the following skills from .github/skills/.
-Copilot loads them automatically when relevant to the task:
+This agent draws on the following skill from .github/skills/. It is **not** auto-loaded — **load the `SKILL.md` on demand** (read it) when estimating:
 
 - **skill-estimation** — When performing project estimation, complexity scoring, PERT, SWOT, cost breakdown
-
-To explicitly invoke a skill, use: /skill-estimation.
 
 ---
 

--- a/agents/al-review-subagent.agent.md
+++ b/agents/al-review-subagent.agent.md
@@ -61,7 +61,7 @@ Use `#changes`, `#usages`, `#problems`, `#search`, `#testFailure` to establish: 
 >
 > **The native residual is dynamic.** With BCQuality present it is A/C/F/G. When BCQuality is **absent** (Step 0 precondition) or returns degraded for a domain, the residual expands to the **full A–G** — the ALDC skills + auto-applied `*.instructions.md` become the primary authority for the affected domains (see the Fallback bullet below for the domain→owner map).
 
-The framework already enforces these rules passively (auto-applied `*.instructions.md` + skills). Do **not** re-derive a rule's text — verify and flag, citing `file:line` for every non-pass (✅ Pass / ⚠️ Could improve / ❌ Fail). Split by who owns the check:
+The framework's rules reach you two ways here — **not** by passive auto-apply (it does not fire in subagent runtime). The **always-on instruction micro-rules** arrive **inline from the Conductor** (hard-rule baseline, in effect for the whole review). For domain **depth**, **load the skill yourself** (read its `SKILL.md`) **only for the residual you actually own** — i.e. domains BCQuality's active dispatch does **not** cover (§"native residual is dynamic"). Where a domain is owned by an enabled BCQuality leaf, do **not** load the ALDC skill — its knowledge is already loaded; defer to its finding. Do **not** re-derive a rule's text — verify and flag, citing `file:line` for every non-pass (✅ Pass / ⚠️ Could improve / ❌ Fail). Split by who owns the check:
 
 **Consume from BCQuality** — Step 0 already returns these *with citations* for the enabled domains. Take its findings; do not re-derive:
 - Performance · Naming & file-pattern · Error handling (Label+Comment, TryFunction) · Commit-in-subscribers · Security/secrets · permission least-privilege.
@@ -83,7 +83,7 @@ You no longer fill a markdown template — the **Conductor renders** the human-f
 - Keep each finding's native DO severity (`blocker | major | minor | info`). The CRITICAL/MAJOR/MINOR naming and the status criteria are the **Conductor's render concern** — not yours.
 - Derive `review.verdict` from the counts baseline (doc §5); use `review.notes` only for a justified override.
 
-**Skills Compliance** goes in `review.skills-compliance[]` — one entry per domain skill `{ skill, status: pass | fail | n-a, evidence }`. Verify the implementer applied the patterns it declared under "### Skills Loaded"; if a skill should have been loaded but wasn't, also emit a `major` finding. Where a row overlaps an enabled BCQuality domain (`skill-performance`↔performance, `skill-permissions`↔security), reference the BCQuality finding rather than re-deriving. What to check per skill:
+**Skills Compliance** goes in `review.skills-compliance[]` — **symbolic**, one entry per domain `{ domain, status }` where status is `✓` (verified native), `↗bcq` (covered by an active BCQuality leaf — deferred, not re-derived, ALDC skill not loaded), or `∅` (n-a). Drop the verbose `evidence` prose — a `file:line` finding already carries the proof. Verify the implementer applied the patterns its **symbolic line** declared (`🧠 skill-x·tag`); if a domain skill should have been applied but wasn't, emit a `major` finding. Check per domain **only for the `✓` residual** (a `↗bcq` domain is BCQuality's, not yours):
 
 | Skill | Verify | n-a when |
 |---|---|---|

--- a/agents/dredd.agent.md
+++ b/agents/dredd.agent.md
@@ -54,7 +54,7 @@ What BCQuality's pilot does not reach — verify and flag, citing `file:line` an
 
 > **The residual is dynamic.** With BCQuality present it is A/C/F/G above. When BCQuality is **absent** (Step 2 precondition) or degraded for a domain, expand to the full **A–G**: add **B. Naming** (`al-naming-conventions`), **D. Performance** (`al-performance` + `skill-performance`), **E. Error handling** (`al-error-handling`), and the commit-in-subscriber / local part of **A** (`al-events`); permissions → `skill-permissions`. Secrets/security has no native check — flag what the instructions reach at `confidence ≤ medium` and note the thinner coverage.
 
-(Authoritative rule text lives in `.github/instructions/*` — don't copy it here.)
+(Authoritative rule text lives in `.github/instructions/*` — don't copy it here. You run **standalone**, with no Conductor to inject it and no `applyTo` auto-apply in this runtime: when a domain falls to the native residual, **read** its governing `instructions/al-*.instructions.md` — and `skill-performance` / `skill-permissions` where the residual names them — and judge against it. Don't rely on ambient enforcement; it doesn't fire here. A domain already owned by an active BCQuality leaf needs no such read — defer to its finding.)
 
 ### Step 4 — Build the Audit-Report JSON
 

--- a/packages/foundation/agents/al-architect.agent.md
+++ b/packages/foundation/agents/al-architect.agent.md
@@ -210,7 +210,7 @@ For **LOW complexity**: skip architect, use `al-spec.create` → `@al-developer`
 
 ## Domain Skills
 
-This agent works with the following skills from `.github/skills/`. Copilot loads them automatically when relevant:
+This agent draws on these skills from `.github/skills/`. They are **not** auto-loaded — **load the `SKILL.md` on demand** (read it) when the design enters that domain:
 
 - **skill-api** — designing API pages, OData endpoints, integration strategy
 - **skill-events** — designing event-driven architecture, publishers/subscribers
@@ -218,7 +218,7 @@ This agent works with the following skills from `.github/skills/`. Copilot loads
 - **skill-copilot** — designing Copilot/AI feature architecture
 - **skill-pages** — designing page layouts, UX patterns, navigation
 
-To explicitly invoke a skill, use: `/skill-api`, `/skill-events`, etc.
+**Load = read the `SKILL.md`.** Naming a skill without reading it is not loading it.
 
 ## Skills Evidencing
 

--- a/packages/foundation/agents/al-conductor.agent.md
+++ b/packages/foundation/agents/al-conductor.agent.md
@@ -164,10 +164,10 @@ Invoke **AL Implementation Subagent** (💻) via `#runSubagent` with:
 - Test requirements following AL-Go structure (`test/` project)
 - AL-specific patterns (SetLoadFields, error handling, naming ≤26 chars)
 - Explicit TDD instruction: tests first (failing), minimal code, tests pass, lint/format
-- Domain skills to load from `.github/skills/` based on phase domain
+- **The 7 always-on instruction micro-rules inline** + **domain skill hints** for this phase (per §"Passing Context to Subagents" — the subagent loads the `SKILL.md` on demand, not you)
 - Instruction: work autonomously, only ask user on critical implementation decisions
 - **NOT** to proceed to next phase or write completion files (you handle this)
-- **RETURN** structured summary: objects created, **event subscribers (exact base object + event name + signature)**, tests created, build status, issues, skills loaded
+- **RETURN** structured summary: objects created, **event subscribers (exact base object + event name + signature)**, tests created, build status, issues, and the **symbolic skills line** (`📐 instr ✓ · 🧠 skill-x·tag`)
 
 **⛔ TDD ENFORCEMENT**: If subagent returns code without tests, REJECT the phase result and re-invoke with explicit TDD instruction. **Zero tests = phase FAILED.**
 
@@ -668,6 +668,8 @@ Instead, **pass phase-relevant excerpts inline** in the `#runSubagent` instructi
 - **Architecture decisions** — only the decisions/constraints this phase must honor (e.g. "use CalcSums, not a FlowField"; "publish IntegrationEvent X"), not the full document.
 - **Test-plan excerpt** — only the tests scoped to this phase.
 - **Memory** — only the cross-session decisions that bear on this phase.
+- **The 7 always-on instruction micro-rules** (`instructions/al-*.instructions.md`) — read them **once** at run start and pass them inline to **every** code-touching subagent (implement, review). They are tiny (~1.3K tokens total) hard-rule baselines, and the `applyTo` auto-apply does **not** fire in subagent runtime (no attached files) — so injecting them is the only way they take effect. **Not optional, not per-domain**: pass all seven on every code phase. They are the floor; the depth lives in the skills they point to.
+- **Domain skill *hints*** — name the skills likely relevant to this phase's domain (e.g. `skill-events` for an event phase). These are **hints, not mandates**: the subagent loads the `SKILL.md` on demand when it enters the domain, and may load a skill you didn't hint if it finds it needs one.
 
 Tell the subagent: **the excerpts are authoritative for this phase; read the full file under `.github/plans/` only if a referenced detail is missing from the excerpt.** Always include the file path so that escape hatch works. This trades a few KB in the invocation prompt for eliminating 5–8 redundant `read_file` round-trips per subagent invocation.
 

--- a/packages/foundation/agents/al-conductor.agent.md
+++ b/packages/foundation/agents/al-conductor.agent.md
@@ -504,11 +504,11 @@ DO NOT proceed past these points without explicit user confirmation.
 
 ## Domain Skills
 
-This agent works with skills from `.github/skills/`. Copilot loads them automatically when relevant:
+This agent draws on skills from `.github/skills/`. They are **not** auto-loaded — **load the `SKILL.md` on demand** (read it) when you need it:
 
 - **skill-testing** — orchestrating TDD cycles when test strategy is needed
 
-Explicit invocation: `/skill-testing`.
+(Per phase, the implement/review subagents load their own domain skills — you pass them as *hints*, see §"Passing Context to Subagents".)
 
 ## Skills Evidencing
 

--- a/packages/foundation/agents/al-implement-subagent.agent.md
+++ b/packages/foundation/agents/al-implement-subagent.agent.md
@@ -80,7 +80,7 @@ Before writing any test code:
 
 ### Object & Pattern Reference
 
-For object-creation patterns, naming, performance and error-handling rules, **rely on the active framework**: the matching micro-instructions in `.github/instructions/al-*` auto-load when you edit `.al` files, and the relevant skill (`skill-events`, `skill-pages`, `skill-permissions`, `skill-performance`, `skill-api`, `skill-copilot`) provides full examples and patterns. Do not invent or duplicate those rules in your responses; load the skill and follow it.
+For object-creation patterns, naming, performance and error-handling rules, **rely on the framework — but know how it reaches you here.** The Conductor passes the **always-on instruction micro-rules inline** in your invocation (the `applyTo` auto-apply does **not** fire in subagent runtime — don't wait for it); treat them as in effect for the whole phase. For the **detail**, each instruction points to its skill: when you enter that domain (`skill-events`, `skill-pages`, `skill-permissions`, `skill-performance`, `skill-api`, `skill-copilot`), **load the skill — read its `SKILL.md` — and follow it**, including a skill the Conductor didn't hint if you find you need it. Do not invent or duplicate the rules; load the skill.
 
 ### Test Patterns (Given/When/Then)
 
@@ -134,8 +134,7 @@ end;
 
 ## Domain Skills
 
-This agent works with the following skills from .github/skills/.
-Copilot loads them automatically when relevant to the task:
+These skills live in `.github/skills/`. They are **not** auto-loaded in subagent runtime — **you load them on demand** (read the `SKILL.md`) when the phase enters the matching domain. The Conductor hints the likely ones; load the one you actually need (and any other you discover you need):
 
 - **skill-api** — When creating API pages, OData endpoints, HttpClient integrations
 - **skill-events** — When implementing event subscribers/publishers
@@ -144,33 +143,25 @@ Copilot loads them automatically when relevant to the task:
 - **skill-copilot** — When implementing Copilot/AI features
 - **skill-testing** — When designing tests, Given/When/Then patterns
 
-To explicitly invoke a skill, use: /skill-api, /skill-testing, etc.
+**Load = read the `SKILL.md`.** Naming a skill without reading it is not loading it.
 
 </domain_skills>
 
-## Skills Evidencing
+## Skills Evidencing (symbolic)
 
-In the **Phase Implementation Summary** (see Output Format), you MUST declare which skills you loaded and which specific pattern you applied from each.
+In the **Phase Implementation Summary**, emit **one symbolic line** — a cheap coverage trace, not a table:
 
-**Format — "### Skills Loaded" in every Phase Summary:**
-
-```markdown
-### Skills Loaded
-- skill-api — Applied: ODataKeyFields, APIPublisher conventions
-- skill-permissions — Applied: PermissionSet generation pattern
+```
+📐 instr ✓ · 🧠 skill-events·EventSub+TryFunc · skill-performance·SetLoadFields
 ```
 
-If no domain skills were required for the phase:
-
-```markdown
-### Skills Loaded
-No domain skills required for this phase.
-```
+- `📐 instr ✓` — the always-on instruction baseline (passed inline by the Conductor) was in effect.
+- `🧠 <skill>·<1–3-word pattern tag>` — one token per skill you **actually read and applied**, with the concrete pattern.
+- None: `📐 instr ✓ · 🧠 none`.
 
 **Rules:**
-- ONE entry per skill loaded (folder name, not file), with the concrete pattern/workflow used
-- This section is MANDATORY — the Conductor uses it to verify skill coverage
-- If you loaded a skill but did not apply any pattern from it, state why (e.g., "skill-events — Loaded but no event patterns applicable to enum-only phase")
+- Only list a skill you genuinely **read** (`SKILL.md`) **and applied** — this line is the Conductor's coverage signal; padding it with unread skills is the evidencing-theater we are removing.
+- Folder name, not file. One token per skill.
 
 <common_al_test_pitfalls>
 
@@ -276,11 +267,8 @@ After completing a phase, return this structured summary to the Conductor:
 ```markdown
 ## Phase {N} Implementation Summary
 
-### Skills Loaded
-- skill-api — Applied: ODataKeyFields, APIPublisher conventions
-- skill-permissions — Applied: PermissionSet generation pattern
-*(List each skill loaded and the specific pattern applied from it.
-If no domain skills were required for this phase: "No domain skills required for this phase.")*
+📐 instr ✓ · 🧠 skill-events·EventSub+TryFunc · skill-performance·SetLoadFields
+*(One symbolic line — only skills you actually read and applied, each with a 1–3 word pattern tag. None → `📐 instr ✓ · 🧠 none`.)*
 
 ### Objects Created
 - {Type} {ID} "{Name}" — {purpose}

--- a/packages/foundation/agents/al-presales.agent.md
+++ b/packages/foundation/agents/al-presales.agent.md
@@ -827,12 +827,9 @@ await createFile('Technical_PreSales/customer-loyalty-system/00-executive-summar
 
 ## Domain Skills
 
-This agent works with the following skills from .github/skills/.
-Copilot loads them automatically when relevant to the task:
+This agent draws on the following skill from .github/skills/. It is **not** auto-loaded — **load the `SKILL.md` on demand** (read it) when estimating:
 
 - **skill-estimation** — When performing project estimation, complexity scoring, PERT, SWOT, cost breakdown
-
-To explicitly invoke a skill, use: /skill-estimation.
 
 ---
 

--- a/packages/foundation/agents/al-review-subagent.agent.md
+++ b/packages/foundation/agents/al-review-subagent.agent.md
@@ -61,7 +61,7 @@ Use `#changes`, `#usages`, `#problems`, `#search`, `#testFailure` to establish: 
 >
 > **The native residual is dynamic.** With BCQuality present it is A/C/F/G. When BCQuality is **absent** (Step 0 precondition) or returns degraded for a domain, the residual expands to the **full A–G** — the ALDC skills + auto-applied `*.instructions.md` become the primary authority for the affected domains (see the Fallback bullet below for the domain→owner map).
 
-The framework already enforces these rules passively (auto-applied `*.instructions.md` + skills). Do **not** re-derive a rule's text — verify and flag, citing `file:line` for every non-pass (✅ Pass / ⚠️ Could improve / ❌ Fail). Split by who owns the check:
+The framework's rules reach you two ways here — **not** by passive auto-apply (it does not fire in subagent runtime). The **always-on instruction micro-rules** arrive **inline from the Conductor** (hard-rule baseline, in effect for the whole review). For domain **depth**, **load the skill yourself** (read its `SKILL.md`) **only for the residual you actually own** — i.e. domains BCQuality's active dispatch does **not** cover (§"native residual is dynamic"). Where a domain is owned by an enabled BCQuality leaf, do **not** load the ALDC skill — its knowledge is already loaded; defer to its finding. Do **not** re-derive a rule's text — verify and flag, citing `file:line` for every non-pass (✅ Pass / ⚠️ Could improve / ❌ Fail). Split by who owns the check:
 
 **Consume from BCQuality** — Step 0 already returns these *with citations* for the enabled domains. Take its findings; do not re-derive:
 - Performance · Naming & file-pattern · Error handling (Label+Comment, TryFunction) · Commit-in-subscribers · Security/secrets · permission least-privilege.
@@ -83,7 +83,7 @@ You no longer fill a markdown template — the **Conductor renders** the human-f
 - Keep each finding's native DO severity (`blocker | major | minor | info`). The CRITICAL/MAJOR/MINOR naming and the status criteria are the **Conductor's render concern** — not yours.
 - Derive `review.verdict` from the counts baseline (doc §5); use `review.notes` only for a justified override.
 
-**Skills Compliance** goes in `review.skills-compliance[]` — one entry per domain skill `{ skill, status: pass | fail | n-a, evidence }`. Verify the implementer applied the patterns it declared under "### Skills Loaded"; if a skill should have been loaded but wasn't, also emit a `major` finding. Where a row overlaps an enabled BCQuality domain (`skill-performance`↔performance, `skill-permissions`↔security), reference the BCQuality finding rather than re-deriving. What to check per skill:
+**Skills Compliance** goes in `review.skills-compliance[]` — **symbolic**, one entry per domain `{ domain, status }` where status is `✓` (verified native), `↗bcq` (covered by an active BCQuality leaf — deferred, not re-derived, ALDC skill not loaded), or `∅` (n-a). Drop the verbose `evidence` prose — a `file:line` finding already carries the proof. Verify the implementer applied the patterns its **symbolic line** declared (`🧠 skill-x·tag`); if a domain skill should have been applied but wasn't, emit a `major` finding. Check per domain **only for the `✓` residual** (a `↗bcq` domain is BCQuality's, not yours):
 
 | Skill | Verify | n-a when |
 |---|---|---|

--- a/packages/foundation/agents/dredd.agent.md
+++ b/packages/foundation/agents/dredd.agent.md
@@ -54,7 +54,7 @@ What BCQuality's pilot does not reach — verify and flag, citing `file:line` an
 
 > **The residual is dynamic.** With BCQuality present it is A/C/F/G above. When BCQuality is **absent** (Step 2 precondition) or degraded for a domain, expand to the full **A–G**: add **B. Naming** (`al-naming-conventions`), **D. Performance** (`al-performance` + `skill-performance`), **E. Error handling** (`al-error-handling`), and the commit-in-subscriber / local part of **A** (`al-events`); permissions → `skill-permissions`. Secrets/security has no native check — flag what the instructions reach at `confidence ≤ medium` and note the thinner coverage.
 
-(Authoritative rule text lives in `.github/instructions/*` — don't copy it here.)
+(Authoritative rule text lives in `.github/instructions/*` — don't copy it here. You run **standalone**, with no Conductor to inject it and no `applyTo` auto-apply in this runtime: when a domain falls to the native residual, **read** its governing `instructions/al-*.instructions.md` — and `skill-performance` / `skill-permissions` where the residual names them — and judge against it. Don't rely on ambient enforcement; it doesn't fire here. A domain already owned by an active BCQuality leaf needs no such read — defer to its finding.)
 
 ### Step 4 — Build the Audit-Report JSON
 


### PR DESCRIPTION
## Qué

Cierra el agujero más serio que destapó el análisis forense: **en orquestación ni las instructions ni las skills se estaban usando.** Era el core de ALDC funcionando en vacío.

### Evidencia (log TestC)
- **Instructions**: las 8 aparecían **`[skipped]`** en *cada* turno → `applyTo '**/*.al' did not match any attached files`. El auto-apply por glob necesita un editor con fichero abierto; los subagentes no lo tienen.
- **Skills**: se *nombraban* en bloques "Skills Loaded" pero **ningún `SKILL.md` se leía** → evidenciadas desde el conocimiento del modelo, no del módulo. Teatro de evidencia.

### Fix (solo prosa), fiel al diseño real
Las instructions son micro-reglas diminutas (~14 líneas c/u, ~1.3K tokens las 7) que **delegan el detalle a las skills** on-demand. Aprovechamos eso:

- **al-conductor**: lee las **7 always-on una vez** e **inyecta inline** en cada subagente de código (cacheado → ~gratis); pasa skills como **hints, no mandatos**.
- **al-implement-subagent**: fuera *"Copilot loads them automatically"* / *"auto-load when you edit .al"* y el `/skill-x` no funcional; **cargar skill = leer su `SKILL.md`** on-demand (incl. una no-hinteada). Evidencing → **una línea simbólica** `📐 instr ✓ · 🧠 skill-x·tag` (sustituye las tablas verbosas).
- **al-review-subagent**: instructions inline; cargar skill de dominio **solo para el residual que BCQuality NO cubre** (sin doble carga); `skills-compliance` → simbólico `{domain, ✓ | ↗bcq | ∅}`.
- **dredd**: standalone → **lee** la instruction/skill del residual nativo en vez de asumir enforcement ambiental.

### Decisiones (acordadas)
- **Instructions: las 7 siempre** (no per-dominio — la maquinaria de clasificación ahorraría ~0 tokens cacheados y arriesga omisiones).
- **Skills: on-demand**, dirigidas por el subagente, con hint del conductor; reviewer/dredd **BCQuality-aware** (no recargar lo que una leaf activa ya cubre).
- **Evidencing: simbólico (Opción B)** — nombre + tag de patrón.

### Notas
- **al-developer (interactivo) intacto**: ahí el `applyTo` sí dispara (editor con ficheros). El fix es solo para la ruta orquestada.
- **al-planning-subagent intacto** a propósito (investiga; no aplica reglas de dominio).
- Net **−20 líneas**. Root + `packages/foundation`. Validador ALDC Core v1.1 ✅ 0 warnings.

https://claude.ai/code/session_01KDEqho2A9337XJvnTVgGxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDEqho2A9337XJvnTVgGxA)_