### PR TITLE
fix(plugin): add root marketplace.json so remote /plugin install works (#84)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "aldc-marketplace",
+  "owner": {
+    "name": "javiarmesto",
+    "url": "https://github.com/javiarmesto"
+  },
+  "metadata": {
+    "description": "ALDC — AI-Native AL Development Collection for Microsoft Dynamics 365 Business Central. Agents, skills, workflows, and coding standards for extension-only development."
+  },
+  "plugins": [
+    {
+      "name": "aldc",
+      "source": "./claude-plugin",
+      "description": "AL agents (incl. on-demand triage + dredd audit) + TDD subagents, skills, and workflows for BC extension development with TDD, BCQuality-cited review, event-driven architecture, and HITL gates.",
+      "version": "4.2.0"
+    }
+  ]
+}


### PR DESCRIPTION
## Fixes #84 — `/plugin marketplace add` "Marketplace file not found"

### Root cause
`/plugin marketplace add javiarmesto/ALDC-AL-Development-Collection` looks for `.claude-plugin/marketplace.json` at the **repository root** (confirmed in the [Claude Code docs](https://code.claude.com/docs/en/plugin-marketplaces): *"Create `.claude-plugin/marketplace.json` in your repository root"*). This repo only had the manifest **nested** at `claude-plugin/.claude-plugin/marketplace.json`, so the remote add fails with exactly:

```
Error: Marketplace file not found at …\.claude\plugins\marketplaces\…\.claude-plugin\marketplace.json
```

(The local method `/plugin marketplace add ./claude-plugin` worked because the manifest *is* at the root of that subdirectory.)

### Fix
Add `.claude-plugin/marketplace.json` at the repo root. Its plugin `source` is `./claude-plugin` — per the docs, source paths resolve relative to the **marketplace root (repo root)**, and `./claude-plugin` is the directory that contains `.claude-plugin/plugin.json` + `agents/skills/commands/hooks`.

### Now working
```
/plugin marketplace add javiarmesto/ALDC-AL-Development-Collection
/plugin install aldc@aldc-marketplace
```

### Verified
- ✅ `marketplace.json` parses; `source: ./claude-plugin` contains `.claude-plugin/plugin.json` and the full plugin structure.
- ✅ Nested `claude-plugin/.claude-plugin/marketplace.json` kept untouched → the local `add ./claude-plugin` path still works.
- ✅ ALDC validator: COMPLIANT, 0 warnings.

> Note: this leaves two marketplace manifests (root + nested) listing the same plugin/version. Kept both to avoid regressing the documented local method; happy to consolidate to a single root manifest (and switch the local docs to `add .`) if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDEqho2A9337XJvnTVgGxA)_